### PR TITLE
SQS code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,28 @@ Stream("testData")
 
 AWS credential chain and region can be configured by overriding the respective fields in the KinesisProducerClient parameter to `writeToKinesis`. Defaults to using the default AWS credentials chain and `us-east-1` for region.
 
-## Kinesis Firehose
-**TODO:** Stream get data, Stream send data
-
 ## SQS
-**TODO:** Stream get SQS messages, Stream send SQS messages
+### Streaming messages from SQS
+Example showng how to stream messages from SQS:
+```scala
+import scala.util.control.Exception
+
+implicit val decoder: javax.jms.Message => Either[Throwable, String] = { msg =>
+  Exception.nonFatal either msg.asInstanceOf[TextMessage].getText
+}
+
+val sqsConfig = SqsConfig("queueName")
+
+readFromSQS[IO, String](
+  sqsConfig,
+  (config, callback) => SQSConsumerBuilder(config, callback))
+  .flatMap { s => fs2.Stream.emits(s.getBytes) }
+  .through(io.file.writeAll(Paths.get("sqsOutput.txt")))
+```
+
+
+### Publishing messages to SQS
+** TODO **
+
+## SNS
+** TODO **

--- a/src/main/scala/fs2/aws/sqs/ConsumerBuilder.scala
+++ b/src/main/scala/fs2/aws/sqs/ConsumerBuilder.scala
@@ -1,4 +1,6 @@
-package fs2.aws.sqs
+package fs2
+package aws
+package sqs
 
 import cats.effect.Effect
 

--- a/src/main/scala/fs2/aws/sqs/ReceiverCallback.scala
+++ b/src/main/scala/fs2/aws/sqs/ReceiverCallback.scala
@@ -1,4 +1,6 @@
-package fs2.aws.sqs
+package fs2
+package aws
+package sqs
 
 import javax.jms.{Message, MessageListener}
 

--- a/src/main/scala/fs2/aws/sqs/SQSConsumer.scala
+++ b/src/main/scala/fs2/aws/sqs/SQSConsumer.scala
@@ -1,4 +1,6 @@
-package fs2.aws.sqs
+package fs2
+package aws
+package sqs
 
 import com.amazon.sqs.javamessaging.SQSConnection
 import javax.jms.MessageListener

--- a/src/main/scala/fs2/aws/sqs/SQSConsumerBuilder.scala
+++ b/src/main/scala/fs2/aws/sqs/SQSConsumerBuilder.scala
@@ -1,4 +1,6 @@
-package fs2.aws.sqs
+package fs2
+package aws
+package sqs
 
 import cats.effect.Effect
 import com.amazon.sqs.javamessaging.{ProviderConfiguration, SQSConnection, SQSConnectionFactory}

--- a/src/main/scala/fs2/aws/sqs/SqsConfig.scala
+++ b/src/main/scala/fs2/aws/sqs/SqsConfig.scala
@@ -1,4 +1,6 @@
-package fs2.aws.sqs
+package fs2
+package aws
+package sqs
 
 import eu.timepit.refined.types.string.TrimmedString
 

--- a/src/main/scala/fs2/aws/sqs/package.scala
+++ b/src/main/scala/fs2/aws/sqs/package.scala
@@ -1,14 +1,14 @@
 package fs2
+package aws
 
 import cats.effect.{ConcurrentEffect, IO}
-import fs2.aws.sqs.{ConsumerBuilder, ReceiverCallback, SqsConfig}
 import fs2.concurrent.Queue
 import javax.jms.{Message, MessageListener}
 
-package object aws {
+package object sqs {
 
-  def sqsStream[F[_], O](sqsConfig: SqsConfig,
-                         builder: (SqsConfig, MessageListener) => ConsumerBuilder[F])(
+  def readFromSQS[F[_], O](sqsConfig: SqsConfig,
+                           builder: (SqsConfig, MessageListener) => ConsumerBuilder[F])(
       implicit F: ConcurrentEffect[F],
       decoder: Message => Either[Throwable, O]): fs2.Stream[F, O] = {
     for {


### PR DESCRIPTION
Rename `sqsStream` to `readFromSqs`. 
Cleanup packaging for SQS