### PR TITLE
Topic/cross build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,8 @@ credentials in ThisBuild += Credentials("Sonatype Nexus Repository Manager",
 
 publishArtifact in ThisBuild in Test := true
 
+updateOptions := updateOptions.value.withGigahorse(false)
+
 // release steps
 releaseProcess := Seq[ReleaseStep](
   inquireVersions,

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ credentials in ThisBuild += Credentials("Sonatype Nexus Repository Manager",
 
 publishArtifact in ThisBuild in Test := true
 
-updateOptions := updateOptions.value.withGigahorse(false)
+updateOptions in ThisBuild := updateOptions.value.withGigahorse(false)
 
 // release steps
 releaseProcess := Seq[ReleaseStep](

--- a/fs2-aws-testkit/src/main/scala/fs2/aws/testkit/package.scala
+++ b/fs2-aws-testkit/src/main/scala/fs2/aws/testkit/package.scala
@@ -16,5 +16,5 @@ package object testkit {
                       Some(d))
   }
 
-  val TestRecordProcessor = new kinesis.RecordProcessor(_ => (), 10.seconds)
+  val TestRecordProcessor = new kinesis.SingleRecordProcessor(_ => (), 10.seconds)
 }

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/ChunkedRecordProcessor.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/ChunkedRecordProcessor.scala
@@ -1,0 +1,36 @@
+package fs2.aws.kinesis
+
+import fs2.Chunk
+import software.amazon.kinesis.lifecycle.events._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
+
+/** Concrete implementation of the AWS RecordProcessor interface.
+  * Wraps incoming records into CommitableRecord types to allow for downstream
+  * checkpointing
+  *
+  *  @constructor create a new instance with a callback function to perform on record receive
+  *  @param cb callback function to run on record receive, passing the new CommittableRecord
+  */
+private[aws] class ChunkedRecordProcessor(cb: Chunk[CommittableRecord] => Unit,
+                                          override val terminateGracePeriod: FiniteDuration)
+    extends RecordProcessor {
+
+  override def processRecords(processRecordsInput: ProcessRecordsInput): Unit = {
+    val batch = processRecordsInput
+      .records()
+      .asScala
+      .map { record =>
+        CommittableRecord(
+          shardId,
+          extendedSequenceNumber,
+          processRecordsInput.millisBehindLatest(),
+          record,
+          recordProcessor = this,
+          processRecordsInput.checkpointer()
+        )
+      }
+    cb(Chunk(batch: _*))
+  }
+}

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/RecordProcessor.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/RecordProcessor.scala
@@ -4,41 +4,22 @@ import software.amazon.kinesis.lifecycle.events._
 import software.amazon.kinesis.processor.ShardRecordProcessor
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber
 
-import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 
 /** Concrete implementation of the AWS RecordProcessor interface.
   * Wraps incoming records into CommitableRecord types to allow for downstream
   * checkpointing
-  *
-  *  @constructor create a new instance with a callback function to perform on record receive
-  *  @param cb callback function to run on record receive, passing the new CommittableRecord
   */
-private[aws] class RecordProcessor(cb: CommittableRecord => Unit,
-                                   terminateGracePeriod: FiniteDuration)
-    extends ShardRecordProcessor {
-  private var shardId: String                                = _
-  private var extendedSequenceNumber: ExtendedSequenceNumber = _
-  private[kinesis] var isShutdown: Boolean                   = false
+private[aws] trait RecordProcessor extends ShardRecordProcessor {
+  val terminateGracePeriod: FiniteDuration
+
+  private[kinesis] var shardId: String                                = _
+  private[kinesis] var extendedSequenceNumber: ExtendedSequenceNumber = _
+  private[kinesis] var isShutdown: Boolean                            = false
 
   override def initialize(initializationInput: InitializationInput): Unit = {
     shardId = initializationInput.shardId()
     extendedSequenceNumber = initializationInput.extendedSequenceNumber()
-  }
-
-  override def processRecords(processRecordsInput: ProcessRecordsInput): Unit = {
-    processRecordsInput.records().asScala.foreach { record =>
-      cb(
-        CommittableRecord(
-          shardId,
-          extendedSequenceNumber,
-          processRecordsInput.millisBehindLatest(),
-          record,
-          recordProcessor = this,
-          processRecordsInput.checkpointer()
-        )
-      )
-    }
   }
 
   override def leaseLost(leaseLostInput: LeaseLostInput): Unit = {}
@@ -52,6 +33,6 @@ private[aws] class RecordProcessor(cb: CommittableRecord => Unit,
   override def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput): Unit = {
     isShutdown = true
     Thread.sleep(terminateGracePeriod.toMillis)
-    shutdownRequestedInput.checkpointer().checkpoint();
+    shutdownRequestedInput.checkpointer().checkpoint()
   }
 }

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/SingleRecordProcessor.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/SingleRecordProcessor.scala
@@ -1,0 +1,32 @@
+package fs2.aws.kinesis
+
+import software.amazon.kinesis.lifecycle.events._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
+
+/** Concrete implementation of the AWS RecordProcessor interface.
+  * Wraps incoming records into CommitableRecord types to allow for downstream
+  * checkpointing
+  *
+  *  @constructor create a new instance with a callback function to perform on record receive
+  *  @param cb callback function to run on record receive, passing the new CommittableRecord
+  */
+private[aws] class SingleRecordProcessor(cb: CommittableRecord => Unit,
+                                         override val terminateGracePeriod: FiniteDuration)
+    extends RecordProcessor {
+  override def processRecords(processRecordsInput: ProcessRecordsInput): Unit = {
+    processRecordsInput.records().asScala.foreach { record =>
+      cb(
+        CommittableRecord(
+          shardId,
+          extendedSequenceNumber,
+          processRecordsInput.millisBehindLatest(),
+          record,
+          recordProcessor = this,
+          processRecordsInput.checkpointer()
+        )
+      )
+    }
+  }
+}

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import cats.effect.{ConcurrentEffect, IO, Timer}
 import cats.implicits._
-import fs2.{Pipe, RaiseThrowable, Sink, Stream}
+import fs2.{Chunk, Pipe, RaiseThrowable, Sink, Stream}
 import fs2.aws.internal._
 import fs2.aws.internal.Exceptions.KinesisCheckpointException
 import fs2.concurrent.Queue
@@ -73,7 +73,7 @@ object consumer {
     }
   }
 
-  /** Intialize a worker and start streaming records from a Kinesis stream
+  /** Initialize a worker and start streaming records from a Kinesis stream
     * On stream finish (due to error or other), worker will be shutdown
     *
     *  @tparam F effect type of the fs2 stream
@@ -83,6 +83,18 @@ object consumer {
   def readFromKinesisStream[F[_]](consumerConfig: KinesisConsumerSettings)(
       implicit F: ConcurrentEffect[F]): Stream[F, CommittableRecord] = {
     readFromKinesisStream(defaultScheduler(_, consumerConfig), consumerConfig)
+  }
+
+  /** Initialize a worker and start streaming records from a Kinesis stream
+    * On stream finish (due to error or other), worker will be shutdown
+    *
+    *  @tparam F effect type of the fs2 stream
+    *  @param consumerConfig configuration parameters for the KCL
+    *  @return an infinite fs2 Stream that emits Kinesis Records Chunks
+    */
+  def readChunkedFromKinesisStream[F[_]](consumerConfig: KinesisConsumerSettings)(
+      implicit F: ConcurrentEffect[F]): Stream[F, Chunk[CommittableRecord]] = {
+    readChunksFromKinesisStream(defaultScheduler(_, consumerConfig), consumerConfig)
   }
 
   /** Intialize a worker and start streaming records from a Kinesis stream
@@ -102,7 +114,7 @@ object consumer {
     def instantiateWorker(queue: Queue[F, CommittableRecord]): F[Scheduler] = F.delay {
       workerFactory(
         () =>
-          new RecordProcessor(
+          new SingleRecordProcessor(
             record => F.runAsync(queue.enqueue1(record))(_ => IO.unit).unsafeRunSync,
             streamConfig.terminateGracePeriod
         )
@@ -113,6 +125,32 @@ object consumer {
     // Expose the elements by dequeuing the internal buffer
     for {
       buffer <- Stream.eval(Queue.bounded[F, CommittableRecord](streamConfig.bufferSize))
+      worker = instantiateWorker(buffer)
+      stream <- buffer.dequeue concurrently Stream.eval(worker.map(_.run)) onFinalize worker.map(
+        _.shutdown)
+    } yield stream
+  }
+
+  private[aws] def readChunksFromKinesisStream[F[_]](
+      workerFactory: => ShardRecordProcessorFactory => Scheduler,
+      streamConfig: KinesisConsumerSettings
+  )(implicit F: ConcurrentEffect[F]): Stream[F, Chunk[CommittableRecord]] = {
+
+    // Initialize a KCL worker which appends to the internal stream queue on message receipt
+    def instantiateWorker(queue: Queue[F, Chunk[CommittableRecord]]): F[Scheduler] = F.delay {
+      workerFactory(
+        () =>
+          new ChunkedRecordProcessor(
+            records => F.runAsync(queue.enqueue1(records))(_ => IO.unit).unsafeRunSync,
+            streamConfig.terminateGracePeriod
+        )
+      )
+    }
+
+    // Instantiate a new bounded queue and concurrently run the queue populator
+    // Expose the elements by dequeuing the internal buffer
+    for {
+      buffer <- Stream.eval(Queue.bounded[F, Chunk[CommittableRecord]](streamConfig.bufferSize))
       worker = instantiateWorker(buffer)
       stream <- buffer.dequeue concurrently Stream.eval(worker.map(_.run)) onFinalize worker.map(
         _.shutdown)

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
@@ -82,7 +82,7 @@ object consumer {
     */
   def readFromKinesisStream[F[_]](consumerConfig: KinesisConsumerSettings)(
       implicit F: ConcurrentEffect[F]): Stream[F, CommittableRecord] = {
-    readFromKinesisStream(defaultScheduler(_, consumerConfig), consumerConfig)
+    readFromKinesisStream(consumerConfig, defaultScheduler(_, consumerConfig))
   }
 
   /** Initialize a worker and start streaming records from a Kinesis stream
@@ -94,7 +94,7 @@ object consumer {
     */
   def readChunkedFromKinesisStream[F[_]](consumerConfig: KinesisConsumerSettings)(
       implicit F: ConcurrentEffect[F]): Stream[F, Chunk[CommittableRecord]] = {
-    readChunksFromKinesisStream(defaultScheduler(_, consumerConfig), consumerConfig)
+    readChunksFromKinesisStream(consumerConfig, defaultScheduler(_, consumerConfig))
   }
 
   /** Intialize a worker and start streaming records from a Kinesis stream

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
@@ -106,8 +106,8 @@ object consumer {
     *  @return an infinite fs2 Stream that emits Kinesis Records
     */
   private[aws] def readFromKinesisStream[F[_]](
-      workerFactory: => ShardRecordProcessorFactory => Scheduler,
-      streamConfig: KinesisConsumerSettings
+      streamConfig: KinesisConsumerSettings,
+      workerFactory: => ShardRecordProcessorFactory => Scheduler
   )(implicit F: ConcurrentEffect[F]): Stream[F, CommittableRecord] = {
 
     // Initialize a KCL worker which appends to the internal stream queue on message receipt
@@ -132,8 +132,8 @@ object consumer {
   }
 
   private[aws] def readChunksFromKinesisStream[F[_]](
-      workerFactory: => ShardRecordProcessorFactory => Scheduler,
-      streamConfig: KinesisConsumerSettings
+      streamConfig: KinesisConsumerSettings,
+      workerFactory: => ShardRecordProcessorFactory => Scheduler
   )(implicit F: ConcurrentEffect[F]): Stream[F, Chunk[CommittableRecord]] = {
 
     // Initialize a KCL worker which appends to the internal stream queue on message receipt

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/publisher.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/publisher.scala
@@ -50,8 +50,9 @@ object publisher {
                 override def onFailure(t: Throwable): Unit = cb(Left(t))
 
                 override def onSuccess(result: UserRecordResult): Unit = cb(Right(result))
-              },
-              (command: Runnable) => ec.execute(command)
+              }, new java.util.concurrent.Executor {
+                def execute(command: Runnable): Unit = ec.execute(command)
+              }
             )
           }
       }

--- a/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
@@ -296,9 +296,13 @@ class KinesisConsumerSpec extends FlatSpec with Matchers with BeforeAndAfterEach
 
     protected val mockScheduler: Scheduler = mock(classOf[Scheduler])
 
-    when(mockScheduler.run()).thenAnswer((_: InvocationOnMock) => ())
+    when(mockScheduler.run()).thenAnswer(new org.mockito.stubbing.Answer[Unit] {
+      def answer(invocation: InvocationOnMock): Unit = ()
+    })
 
-    when(mockScheduler.shutdown()).thenAnswer((_: InvocationOnMock) => ())
+    when(mockScheduler.shutdown()).thenAnswer(new org.mockito.stubbing.Answer[Unit] {
+      def answer(invocation: InvocationOnMock): Unit = ()
+    })
 
     var recordProcessorFactory: ShardRecordProcessorFactory = _
     var recordProcessor: ShardRecordProcessor               = _

--- a/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
@@ -14,7 +14,6 @@ import fs2.aws.kinesis.{
 }
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.stubbing.Answer
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time._
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
@@ -89,7 +88,7 @@ class KinesisConsumerSpec extends FlatSpec with Matchers with BeforeAndAfterEach
     }
 
     // Should process all 10 messages
-    eventually(output.size shouldBe (10))
+    eventually(output.size shouldBe 10)
 
     // Send a batch that exceeds the internal buffer size
     for (i <- 1 to 50) {
@@ -99,7 +98,7 @@ class KinesisConsumerSpec extends FlatSpec with Matchers with BeforeAndAfterEach
     }
 
     // Should have processed all 60 messages
-    eventually(output.size shouldBe (60))
+    eventually(output.size shouldBe 60)
 
     eventually(verify(mockScheduler, times(0)).shutdown())
     semaphore.release()
@@ -125,7 +124,7 @@ class KinesisConsumerSpec extends FlatSpec with Matchers with BeforeAndAfterEach
     }
 
     // Should process all 10 messages
-    eventually(output.size shouldBe (10))
+    eventually(output.size shouldBe 10)
 
     // Each shard is assigned its own worker thread, so we get messages
     // from each thread simultaneously.
@@ -143,7 +142,7 @@ class KinesisConsumerSpec extends FlatSpec with Matchers with BeforeAndAfterEach
     simulateWorkerThread(recordProcessor2)
 
     // Should have processed all 60 messages
-    eventually(output.size shouldBe (60))
+    eventually(output.size shouldBe 60)
     semaphore.release()
   }
 
@@ -297,13 +296,9 @@ class KinesisConsumerSpec extends FlatSpec with Matchers with BeforeAndAfterEach
 
     protected val mockScheduler: Scheduler = mock(classOf[Scheduler])
 
-    when(mockScheduler.run()).thenAnswer(new Answer[Unit] {
-      override def answer(invocation: InvocationOnMock): Unit = ()
-    })
+    when(mockScheduler.run()).thenAnswer((_: InvocationOnMock) => ())
 
-    when(mockScheduler.shutdown()).thenAnswer(new Answer[Unit] {
-      override def answer(invocation: InvocationOnMock): Unit = ()
-    })
+    when(mockScheduler.shutdown()).thenAnswer((_: InvocationOnMock) => ())
 
     var recordProcessorFactory: ShardRecordProcessorFactory = _
     var recordProcessor: ShardRecordProcessor               = _
@@ -321,7 +316,7 @@ class KinesisConsumerSpec extends FlatSpec with Matchers with BeforeAndAfterEach
       KinesisConsumerSettings("testStream", "testApp", Region.US_EAST_1, 10, 10, 10.seconds).right.get
 
     val stream =
-      readFromKinesisStream[IO](builder, config)
+      readFromKinesisStream[IO](config, builder)
         .through(_.evalMap(i => IO(output = output :+ i)))
         .map(i => if (errorStream) throw new Exception("boom") else i)
         .compile

--- a/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
@@ -10,7 +10,7 @@ import fs2.aws.kinesis.{
   CommittableRecord,
   KinesisCheckpointSettings,
   KinesisConsumerSettings,
-  RecordProcessor
+  SingleRecordProcessor
 }
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
@@ -359,7 +359,7 @@ class KinesisConsumerSpec extends FlatSpec with Matchers with BeforeAndAfterEach
   }
 
   private trait KinesisWorkerCheckpointContext {
-    val recordProcessor    = new RecordProcessor(_ => (), 1.seconds)
+    val recordProcessor    = new SingleRecordProcessor(_ => (), 1.seconds)
     val checkpointerShard1 = mock(classOf[ShardRecordProcessorCheckpointer])
     val settings =
       KinesisCheckpointSettings(maxBatchSize = Int.MaxValue, maxBatchWait = 500.millis).right

--- a/fs2-aws/src/test/scala/fs2/aws/utils/package.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/utils/package.scala
@@ -18,7 +18,7 @@ package object utils {
           IO[Either[Throwable, ByteArrayInputStream]] {
             val fileContent: Array[Byte] =
               try {
-                Source.fromResource(goe.getKey).mkString.getBytes
+                Source.fromInputStream(Thread.currentThread.getContextClassLoader.getResourceAsStream(goe.getKey)).mkString.getBytes
               } catch {
                 case _: FileNotFoundException => throw new AmazonS3Exception("File not found")
                 case e: Throwable             => throw e
@@ -48,7 +48,7 @@ package object utils {
       IO[ByteArrayInputStream] {
         val fileContent: Array[Byte] =
           try {
-            Source.fromResource(getObjectRequest.getKey).mkString.getBytes
+            Source.fromInputStream(Thread.currentThread.getContextClassLoader.getResourceAsStream(getObjectRequest.getKey)).mkString.getBytes
           } catch {
             case _: FileNotFoundException => throw new AmazonS3Exception("File not found")
             case e: Throwable             => throw e

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.27.1"
+version in ThisBuild := "0.27.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.27.2"
+version in ThisBuild := "0.27.3"


### PR DESCRIPTION
This PR backports fs2-aws to Scala 2.11. It's based on v0.27.3, and so apparently won't merge cleanly with master, but I imagine that's nothing a rebase won't take care of—the changes are very minimal, consisting of:

1. Adding the cross-building support to `build.sbt` exactly as documented in the sbt user guide.
2. Adding the `-target:jvm-1.8` `scalacOption`.
3. Making implicit SAM type construction explicit.

Thanks so much for this work!