### PR TITLE
Expose configuration to allow client to specify initial position in topic for Kinesis consumers

### DIFF
--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
@@ -51,7 +51,9 @@ object consumer {
       configsBuilder.lifecycleConfig(),
       configsBuilder.metricsConfig(),
       configsBuilder.processorConfig(),
-      configsBuilder.retrievalConfig()
+      configsBuilder
+        .retrievalConfig()
+        .initialPositionInStreamExtended(settings.initialPositionInStreamExtended)
     )
   }
 


### PR DESCRIPTION
Allows client to start a consumer which will begin processing messages at a given timestamp, or the oldest messages in a topic - see here for more info: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html