### PR TITLE
Allow default amazon client to overriden

### DIFF
--- a/fs2-aws/src/main/scala/fs2/aws/internal/S3Client.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/internal/S3Client.scala
@@ -9,8 +9,8 @@ import com.amazonaws.services.s3.model._
 import scala.collection.JavaConverters._
 import scala.util.control.Exception
 
-object S3Client{
-  def apply[F[_]](amazonS3: AmazonS3): S3Client[F] = new S3Client[F]{
+object S3Client {
+  def apply[F[_]](amazonS3: AmazonS3): S3Client[F] = new S3Client[F] {
     override lazy val client: AmazonS3 = amazonS3
   }
 }

--- a/fs2-aws/src/main/scala/fs2/aws/internal/S3Client.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/internal/S3Client.scala
@@ -3,14 +3,20 @@ package fs2.aws.internal
 import java.io.InputStream
 
 import cats.effect.Effect
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.services.s3.model._
 
 import scala.collection.JavaConverters._
 import scala.util.control.Exception
 
-private[aws] trait S3Client[F[_]] {
-  private lazy val client = AmazonS3ClientBuilder.defaultClient
+object S3Client{
+  def apply[F[_]](amazonS3: AmazonS3): S3Client[F] = new S3Client[F]{
+    override lazy val client: AmazonS3 = amazonS3
+  }
+}
+
+trait S3Client[F[_]] {
+  protected lazy val client: AmazonS3 = AmazonS3ClientBuilder.defaultClient
 
   def getObjectContentOrError(getObjectRequest: GetObjectRequest)(
       implicit F: Effect[F]): F[Either[Throwable, InputStream]] =


### PR DESCRIPTION
It's useful to be able to override the default client configuration and use a different configuration.

This PR removes the private scoping of S3Client and introduces a factory method to the S3Client companion object which allows a new S3Client to be created from an instance of AmazonS3.