### PR TITLE
Correct Unit use

### DIFF
--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
@@ -286,6 +286,6 @@ object consumer {
       checkpointSettings: KinesisCheckpointSettings = KinesisCheckpointSettings.defaultInstance
   )(implicit F: ConcurrentEffect[F], timer: Timer[F]): Pipe[F, CommittableRecord, Unit] = {
     _.through(checkpointRecords(checkpointSettings))
-      .map(_ => ())
+      .void
   }
 }

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/publisher.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/publisher.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.kinesis.producer.UserRecordResult
 import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
 import fs2.aws.internal._
 import fs2.{Pipe, Stream}
+import cats.implicits._
 
 import scala.concurrent.ExecutionContext
 
@@ -74,7 +75,7 @@ object publisher {
       producer: KinesisProducerClient[F] = new KinesisProducerClientImpl[F]
   ): Pipe[F, (String, ByteBuffer), Unit] = {
 
-    _.through(write(streamName, producer)).as(Unit)
+    _.through(write(streamName, producer)).void
   }
 
   /** Writes the (partitionKey, payload) to a Kinesis stream via a Pipe
@@ -116,6 +117,6 @@ object publisher {
       producer: KinesisProducerClient[F] = new KinesisProducerClientImpl[F]
   )(implicit ec: ExecutionContext): Pipe[F, (String, ByteBuffer), Unit] = {
     _.through(writeToKinesis(streamName, parallelism, producer))
-      .map(_ => ())
+      .void
   }
 }


### PR DESCRIPTION
Accidental use of `.as(Unit)` rather than `.as(())` or `.void`