### PR TITLE
Allow passing of custom AmazonS3 client

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,79 @@
-align = true
+version=2.3.2
+
 maxColumn = 100
+
+align.tokens = [
+  {
+    code = "←"
+    owner = "Enumerator.Generator"
+  }, {
+    code = "%"
+    owner = "Term.ApplyInfix"
+  }, {
+    code = "{"
+    owner = Template
+  }, {
+    code = "⇒"
+    owner = Case
+  }, {
+    code = extends
+    owner = "Defn.(Class|Trait|Object)"
+  }, {
+    code = "→"
+    owner = "Term.ApplyInfix"
+  }, {
+    code = "="
+    owner = "(Enumerator.Val|Defn.(Va(l|r)|Def|Type))"
+  }, {
+    code = "<-"
+    owner = "Enumerator.Generator"
+  }, {
+    code = "//"
+    owner = ".*"
+  }, {
+    code = "->"
+    owner = "Term.ApplyInfix"
+  }, {
+    code = "%%"
+    owner = "Term.ApplyInfix"
+  }, {
+    code = "=>"
+    owner = Case
+  }, {
+    code = "}"
+    owner = Template
+  }, {
+    code = "%%%"
+    owner = "Term.ApplyInfix"
+  },
+  ":=",
+  "+=",
+  "++=",
+  in,
+  shouldBe,
+  should,
+  be
+]
+
+align.openParenCallSite = false
+align.openParenDefnSite = false
+align.arrowEnumeratorGenerator = true
+align.tokenCategory.Equals = Assign
+align.tokenCategory.LeftArrow = Assign
+
+danglingParentheses = true
+
+rewrite.rules = [SortImports, RedundantBraces, SortModifiers, PreferCurlyFors]
+rewrite.redundantBraces.stringInterpolation = true
+rewrite.redundantBraces.includeUnitMethods = true
+
+spaces.inImportCurlyBraces = true
+spaces.inByNameTypes = false
+
+newlines.sometimesBeforeColonInMethodReturnType = false
+newlines.penalizeSingleSelectMultiArgList = false
+newlines.neverInResultType = true
+newlines.afterImplicitKWInVerticalMultiline = true
+newlines.beforeImplicitKWInVerticalMultiline = true
+
+continuationIndent.defnSite = 2

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := "fs2-aws"
+name         := "fs2-aws"
 organization in ThisBuild := "io.github.dmateusp"
 
 scalaVersion := "2.12.10"
@@ -6,15 +6,15 @@ scalaVersion := "2.12.10"
 scalacOptions in ThisBuild ++= Seq(
   "-target:jvm-1.8",
   "-encoding",
-  "UTF-8", // source files are in UTF-8
-  "-deprecation", // warn about use of deprecated APIs
-  "-unchecked", // warn about unchecked type parameters
-  "-feature", // warn about misused language features
-  "-language:higherKinds", // allow higher kinded types without `import scala.language.higherKinds`
+  "UTF-8",                         // source files are in UTF-8
+  "-deprecation",                  // warn about use of deprecated APIs
+  "-unchecked",                    // warn about unchecked type parameters
+  "-feature",                      // warn about misused language features
+  "-language:higherKinds",         // allow higher kinded types without `import scala.language.higherKinds`
   "-language:implicitConversions", // allow use of implicit conversions
-  "-Xlint", // enable handy linter warnings
-  "-Xfatal-warnings", // turn compiler warnings into errors
-  "-Ypartial-unification" // allow the compiler to unify type constructors of different arities
+  "-Xlint",                        // enable handy linter warnings
+  "-Xfatal-warnings",              // turn compiler warnings into errors
+  "-Ypartial-unification"          // allow the compiler to unify type constructors of different arities
 )
 lazy val root = (project in file("."))
   .aggregate(`fs2-aws`, `fs2-aws-testkit`)
@@ -29,30 +29,36 @@ addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.10")
 
 // publish
 publishTo in ThisBuild := Some(
-  "Sonatype Nexus" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
+  "Sonatype Nexus" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+)
 
 licenses in ThisBuild := Seq(
-  "MIT" -> url("https://github.com/dmateusp/fs2-aws/blob/master/LICENSE"))
+  "MIT" -> url("https://github.com/dmateusp/fs2-aws/blob/master/LICENSE")
+)
 developers in ThisBuild := List(
-  Developer(id = "dmateusp",
-            name = "Daniel Mateus Pires",
-            email = "dmateusp@gmail.com",
-            url = url("https://github.com/dmateusp"))
+  Developer(
+    id = "dmateusp",
+    name = "Daniel Mateus Pires",
+    email = "dmateusp@gmail.com",
+    url = url("https://github.com/dmateusp")
+  )
 )
 homepage in ThisBuild := Some(url("https://github.com/dmateusp/fs2-aws"))
-scmInfo in ThisBuild := Some(
-  ScmInfo(url("https://github.com/dmateusp/fs2-aws"),
-          "scm:git:git@github.com:dmateusp/fs2-aws.git"))
+scmInfo  in ThisBuild := Some(
+  ScmInfo(url("https://github.com/dmateusp/fs2-aws"), "scm:git:git@github.com:dmateusp/fs2-aws.git")
+)
 
 // release
 import ReleaseTransformations._
 
 // signed releases
 releasePublishArtifactsAction in ThisBuild := PgpKeys.publishSigned.value
-credentials in ThisBuild += Credentials("Sonatype Nexus Repository Manager",
-                                        "oss.sonatype.org",
-                                        sys.env.getOrElse("SONATYPE_USERNAME", ""),
-                                        sys.env.getOrElse("SONATYPE_PASSWORD", ""))
+credentials                   in ThisBuild += Credentials(
+  "Sonatype Nexus Repository Manager",
+  "oss.sonatype.org",
+  sys.env.getOrElse("SONATYPE_USERNAME", ""),
+  sys.env.getOrElse("SONATYPE_PASSWORD", "")
+)
 
 publishArtifact in ThisBuild in Test := true
 
@@ -66,5 +72,5 @@ releaseProcess := Seq[ReleaseStep](
   pushChanges
 )
 
-releaseTagComment := s"Releasing ${(version in ThisBuild).value}"
+releaseTagComment    := s"Releasing ${(version                        in ThisBuild).value}"
 releaseCommitMessage := s"[skip travis] Setting version to ${(version in ThisBuild).value}"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "fs2-aws"
 organization in ThisBuild := "io.github.dmateusp"
 
-scalaVersion := "2.12.9"
+scalaVersion := "2.12.10"
 
 scalacOptions in ThisBuild ++= Seq(
   "-target:jvm-1.8",

--- a/fs2-aws-testkit/build.sbt
+++ b/fs2-aws-testkit/build.sbt
@@ -5,6 +5,7 @@ scalaVersion := "2.12.9"
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest"   % "3.0.8",
-  "org.mockito"   % "mockito-core" % "3.1.0"
+  "org.scalatest" %% "scalatest"   % "3.1.0",
+  "org.mockito"   % "mockito-core" % "3.2.4",
+  "org.mockito"   %% "mockito-scala-scalatest" % "1.11.2"
 )

--- a/fs2-aws-testkit/build.sbt
+++ b/fs2-aws-testkit/build.sbt
@@ -5,7 +5,7 @@ scalaVersion := "2.12.9"
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest"   % "3.1.0",
-  "org.mockito"   % "mockito-core" % "3.2.4",
+  "org.scalatest" %% "scalatest"               % "3.1.0",
+  "org.mockito"   % "mockito-core"             % "3.2.4",
   "org.mockito"   %% "mockito-scala-scalatest" % "1.11.2"
 )

--- a/fs2-aws-testkit/src/main/scala/fs2/aws/testkit/TestKinesisProducerClient.scala
+++ b/fs2-aws-testkit/src/main/scala/fs2/aws/testkit/TestKinesisProducerClient.scala
@@ -7,11 +7,12 @@ import com.amazonaws.services.kinesis.producer.UserRecordResult
 import com.google.common.util.concurrent.ListenableFuture
 import fs2.aws.internal.KinesisProducerClient
 
-case class TestKinesisProducerClient[F[_]](respondWith: UserRecordResult,
-                                           ops: F[ListenableFuture[UserRecordResult]])
-    extends KinesisProducerClient[F] {
+case class TestKinesisProducerClient[F[_]](
+  respondWith: UserRecordResult,
+  ops: F[ListenableFuture[UserRecordResult]]
+) extends KinesisProducerClient[F] {
   override def putData(streamName: String, partitionKey: String, data: ByteBuffer)(
-      implicit e: Sync[F]): F[ListenableFuture[UserRecordResult]] = {
+    implicit e: Sync[F]
+  ): F[ListenableFuture[UserRecordResult]] =
     ops
-  }
 }

--- a/fs2-aws-testkit/src/main/scala/fs2/aws/testkit/TestSqsConsumerBuilder.scala
+++ b/fs2-aws-testkit/src/main/scala/fs2/aws/testkit/TestSqsConsumerBuilder.scala
@@ -4,7 +4,7 @@ import com.amazon.sqs.javamessaging.SQSConnection
 import fs2.aws.testkit.TestSqsConsumerBuilder.TestSQSConsumer
 import fs2.aws.sqs.{ConsumerBuilder, SQSConsumer}
 import javax.jms.MessageListener
-import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.scalatest.MockitoSugar
 
 class TestSqsConsumerBuilder[F[_]: Effect] extends ConsumerBuilder[F] {
   override def start: F[SQSConsumer] =

--- a/fs2-aws-testkit/src/main/scala/fs2/aws/testkit/TestSqsConsumerBuilder.scala
+++ b/fs2-aws-testkit/src/main/scala/fs2/aws/testkit/TestSqsConsumerBuilder.scala
@@ -2,7 +2,7 @@ package fs2.aws.testkit
 import cats.effect.Effect
 import com.amazon.sqs.javamessaging.SQSConnection
 import fs2.aws.testkit.TestSqsConsumerBuilder.TestSQSConsumer
-import fs2.aws.sqs.{ConsumerBuilder, SQSConsumer}
+import fs2.aws.sqs.{ ConsumerBuilder, SQSConsumer }
 import javax.jms.MessageListener
 import org.mockito.scalatest.MockitoSugar
 

--- a/fs2-aws-testkit/src/main/scala/fs2/aws/testkit/package.scala
+++ b/fs2-aws-testkit/src/main/scala/fs2/aws/testkit/package.scala
@@ -4,17 +4,18 @@ import cats.effect.ConcurrentEffect
 import cats.effect.concurrent.Deferred
 import eu.timepit.refined.auto._
 import fs2.aws.sqs.SqsConfig
-import javax.jms.{Message, MessageListener}
+import javax.jms.{ Message, MessageListener }
 import scala.concurrent.duration._
 
 package object testkit {
   def sqsStream[F[_]: ConcurrentEffect, O](
-      d: Deferred[F, MessageListener]
-  )(implicit decoder: Message => Either[Throwable, O]): fs2.Stream[F, O] = {
-    fs2.aws.sqsStream(SqsConfig("dummy"),
-                      (_: SqsConfig, _: MessageListener) => new TestSqsConsumerBuilder[F],
-                      Some(d))
-  }
+    d: Deferred[F, MessageListener]
+  )(implicit decoder: Message => Either[Throwable, O]): fs2.Stream[F, O] =
+    fs2.aws.sqsStream(
+      SqsConfig("dummy"),
+      (_: SqsConfig, _: MessageListener) => new TestSqsConsumerBuilder[F],
+      Some(d)
+    )
 
   val TestRecordProcessor = new kinesis.SingleRecordProcessor(_ => (), 10.seconds)
 }

--- a/fs2-aws/build.sbt
+++ b/fs2-aws/build.sbt
@@ -8,26 +8,27 @@ scalaVersion := "2.12.9"
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 
-val fs2Version    = "2.0.1"
-val AwsSdkVersion = "1.11.687"
+val fs2Version    = "2.2.2"
+val AwsSdkVersion = "1.11.716"
 val cirisVersion  = "0.12.1"
 
 libraryDependencies ++= Seq(
   "co.fs2"                  %% "fs2-core"                     % fs2Version,
   "co.fs2"                  %% "fs2-io"                       % fs2Version,
-  "org.typelevel"           %% "alleycats-core"               % "2.0.0",
+  "org.typelevel"           %% "alleycats-core"               % "2.1.0",
   "com.amazonaws"           % "aws-java-sdk-kinesis"          % AwsSdkVersion,
   "com.amazonaws"           % "aws-java-sdk-s3"               % AwsSdkVersion,
   "com.amazonaws"           % "aws-java-sdk-sqs"              % AwsSdkVersion,
   "com.amazonaws"           % "amazon-kinesis-producer"       % "0.14.0",
-  "software.amazon.kinesis" % "amazon-kinesis-client"         % "2.2.7",
-  "software.amazon.awssdk"  % "sts"                           % "2.10.29",
-  "org.scalatest"           %% "scalatest"                    % "3.0.8" % Test,
-  "org.mockito"             % "mockito-core"                  % "3.1.0" % Test,
+  "software.amazon.kinesis" % "amazon-kinesis-client"         % "2.2.8",
+  "software.amazon.awssdk"  % "sts"                           % "2.10.58",
+  "org.scalatest"           %% "scalatest"                    % "3.1.0" % Test,
+  "org.mockito"             % "mockito-core"                  % "3.2.4" % Test,
+  "org.mockito"             %% "mockito-scala-scalatest"      % "1.11.2" % Test,
   "com.amazonaws"           % "aws-java-sdk-sqs"              % AwsSdkVersion excludeAll ("commons-logging", "commons-logging"),
   "com.amazonaws"           % "amazon-sqs-java-messaging-lib" % "1.0.8" excludeAll ("commons-logging", "commons-logging"),
   "is.cir"                  %% "ciris-core"                   % cirisVersion,
   "is.cir"                  %% "ciris-enumeratum"             % cirisVersion,
   "is.cir"                  %% "ciris-refined"                % cirisVersion,
-  "eu.timepit"              %% "refined"                      % "0.9.10"
+  "eu.timepit"              %% "refined"                      % "0.9.12"
 )

--- a/fs2-aws/build.sbt
+++ b/fs2-aws/build.sbt
@@ -1,7 +1,7 @@
 name := "fs2-aws"
 
 // coverage
-coverageMinimum := 40
+coverageMinimum       := 40
 coverageFailOnMinimum := true
 
 scalaVersion := "2.12.9"

--- a/fs2-aws/src/main/scala/fs2/aws/internal/KinesisProducerClient.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/internal/KinesisProducerClient.scala
@@ -3,7 +3,7 @@ package fs2.aws.internal
 import java.nio.ByteBuffer
 
 import cats.effect.Sync
-import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.auth.{ AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain }
 import com.amazonaws.services.kinesis.producer.{
   KinesisProducer,
   KinesisProducerConfiguration,
@@ -13,7 +13,8 @@ import com.google.common.util.concurrent.ListenableFuture
 
 trait KinesisProducerClient[F[_]] {
   def putData(streamName: String, partitionKey: String, data: ByteBuffer)(
-      implicit F: Sync[F]): F[ListenableFuture[UserRecordResult]]
+    implicit F: Sync[F]
+  ): F[ListenableFuture[UserRecordResult]]
 }
 
 class KinesisProducerClientImpl[F[_]] extends KinesisProducerClient[F] {
@@ -32,6 +33,7 @@ class KinesisProducerClientImpl[F[_]] extends KinesisProducerClient[F] {
   private lazy val client = new KinesisProducer(config)
 
   override def putData(streamName: String, partitionKey: String, data: ByteBuffer)(
-      implicit F: Sync[F]): F[ListenableFuture[UserRecordResult]] =
+    implicit F: Sync[F]
+  ): F[ListenableFuture[UserRecordResult]] =
     F.delay(client.addUserRecord(streamName, partitionKey, data))
 }

--- a/fs2-aws/src/main/scala/fs2/aws/internal/S3Client.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/internal/S3Client.scala
@@ -12,29 +12,32 @@ import scala.util.control.Exception
 private[aws] trait S3Client[F[_]] {
   private lazy val client = AmazonS3ClientBuilder.defaultClient
 
-  def getObjectContentOrError(getObjectRequest: GetObjectRequest)(
-      implicit F: Effect[F]): F[Either[Throwable, InputStream]] =
+  def getObjectContentOrError(
+    getObjectRequest: GetObjectRequest
+  )(implicit F: Effect[F]): F[Either[Throwable, InputStream]] =
     F.delay(Exception.nonFatalCatch either client.getObject(getObjectRequest).getObjectContent)
 
   def getObjectContent(getObjectRequest: GetObjectRequest)(implicit F: Effect[F]): F[InputStream] =
     F.delay(client.getObject(getObjectRequest).getObjectContent)
 
-  def initiateMultipartUpload(initiateMultipartUploadRequest: InitiateMultipartUploadRequest)(
-      implicit F: Effect[F]): F[InitiateMultipartUploadResult] =
+  def initiateMultipartUpload(
+    initiateMultipartUploadRequest: InitiateMultipartUploadRequest
+  )(implicit F: Effect[F]): F[InitiateMultipartUploadResult] =
     F.delay(client.initiateMultipartUpload(initiateMultipartUploadRequest))
 
   def uploadPart(uploadPartRequest: UploadPartRequest)(implicit F: Effect[F]): F[UploadPartResult] =
     F.delay(client.uploadPart(uploadPartRequest))
 
-  def completeMultipartUpload(completeMultipartUploadRequest: CompleteMultipartUploadRequest)(
-      implicit F: Effect[F]): F[CompleteMultipartUploadResult] =
+  def completeMultipartUpload(
+    completeMultipartUploadRequest: CompleteMultipartUploadRequest
+  )(implicit F: Effect[F]): F[CompleteMultipartUploadResult] =
     F.delay(client.completeMultipartUpload(completeMultipartUploadRequest))
 
-  def s3ObjectSummaries(listObjectsV2Request: ListObjectsV2Request)(
-      implicit F: Effect[F]): F[List[S3ObjectSummary]] =
+  def s3ObjectSummaries(
+    listObjectsV2Request: ListObjectsV2Request
+  )(implicit F: Effect[F]): F[List[S3ObjectSummary]] =
     F.delay(client.listObjectsV2(listObjectsV2Request).getObjectSummaries.asScala.toList)
 
-  def getObject(objectRequest: GetObjectRequest)(implicit F: Effect[F]): F[S3Object] = {
+  def getObject(objectRequest: GetObjectRequest)(implicit F: Effect[F]): F[S3Object] =
     F.delay(client.getObject(objectRequest))
-  }
 }

--- a/fs2-aws/src/main/scala/fs2/aws/internal/S3Client.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/internal/S3Client.scala
@@ -3,14 +3,23 @@ package fs2.aws.internal
 import java.io.InputStream
 
 import cats.effect.Effect
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model._
 
 import scala.collection.JavaConverters._
 import scala.util.control.Exception
 
+private[aws] object S3Client {
+  def apply[F[_]](s3: AmazonS3) = new S3ClientImpl[F](s3)
+}
+
+private[aws] class S3ClientImpl[F[_]](c: AmazonS3) extends S3Client[F] {
+  override def client: AmazonS3 = c
+}
+
 private[aws] trait S3Client[F[_]] {
-  private lazy val client = AmazonS3ClientBuilder.defaultClient
+
+  def client: AmazonS3
 
   def getObjectContentOrError(
     getObjectRequest: GetObjectRequest

--- a/fs2-aws/src/main/scala/fs2/aws/internal/package.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/internal/package.scala
@@ -4,7 +4,7 @@ import cats.effect.Concurrent
 import cats.effect.concurrent.Ref
 import cats.implicits._
 import fs2.concurrent.Queue
-import fs2.{Pipe, Stream}
+import fs2.{ Pipe, Stream }
 import alleycats.std.all._
 
 package object internal {
@@ -23,8 +23,9 @@ package object internal {
     *  @param selector partitioning function based on the element
     *  @return a FS2 pipe producing a new sub-stream of elements grouped by the selector
     */
-  def groupBy[F[_], A, K](selector: A => F[K])(
-      implicit F: Concurrent[F]): Pipe[F, A, (K, Stream[F, A])] = { in =>
+  def groupBy[F[_], A, K](
+    selector: A => F[K]
+  )(implicit F: Concurrent[F]): Pipe[F, A, (K, Stream[F, A])] = { in =>
     Stream.eval(Ref.of[F, Map[K, Queue[F, Option[A]]]](Map.empty)).flatMap { queueMap =>
       val cleanup = {
         queueMap.get.flatMap(_.traverse_(_.enqueue1(None)))

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/ChunkedRecordProcessor.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/ChunkedRecordProcessor.scala
@@ -13,9 +13,10 @@ import scala.concurrent.duration.FiniteDuration
   *  @constructor create a new instance with a callback function to perform on record receive
   *  @param cb callback function to run on record receive, passing the new CommittableRecord
   */
-private[aws] class ChunkedRecordProcessor(cb: Chunk[CommittableRecord] => Unit,
-                                          override val terminateGracePeriod: FiniteDuration)
-    extends RecordProcessor {
+private[aws] class ChunkedRecordProcessor(
+  cb: Chunk[CommittableRecord] => Unit,
+  override val terminateGracePeriod: FiniteDuration
+) extends RecordProcessor {
 
   override def processRecords(processRecordsInput: ProcessRecordsInput): Unit = {
     val batch = processRecordsInput

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/CommittableRecord.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/CommittableRecord.scala
@@ -14,12 +14,12 @@ import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber
   *  @param checkpointer reference to the checkpointer used to commit this record
   */
 case class CommittableRecord(
-    shardId: String,
-    recordProcessorStartingSequenceNumber: ExtendedSequenceNumber,
-    millisBehindLatest: Long,
-    record: KinesisClientRecord,
-    recordProcessor: RecordProcessor,
-    checkpointer: RecordProcessorCheckpointer
+  shardId: String,
+  recordProcessorStartingSequenceNumber: ExtendedSequenceNumber,
+  millisBehindLatest: Long,
+  record: KinesisClientRecord,
+  recordProcessor: RecordProcessor,
+  checkpointer: RecordProcessorCheckpointer
 ) {
   val sequenceNumber: String  = record.sequenceNumber()
   val subSequenceNumber: Long = record.subSequenceNumber()
@@ -38,5 +38,6 @@ object CommittableRecord {
       (cr.sequenceNumber, cr.record match {
         case ur: KinesisClientRecord ⇒ ur.subSequenceNumber()
         case _                       ⇒ 0
-      }))
+      })
+    )
 }

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/KinesisSettings.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/KinesisSettings.scala
@@ -17,24 +17,24 @@ import scala.concurrent.duration._
   *  @param stsAssumeRole If present, the configured client will be setup for AWS cross-account access using the provided tokens
   */
 class KinesisConsumerSettings private (
-    val streamName: String,
-    val appName: String,
-    val region: Region,
-    val maxConcurrency: Int,
-    val bufferSize: Int,
-    val terminateGracePeriod: FiniteDuration,
-    val stsAssumeRole: Option[STSAssumeRoleSettings]
+  val streamName: String,
+  val appName: String,
+  val region: Region,
+  val maxConcurrency: Int,
+  val bufferSize: Int,
+  val terminateGracePeriod: FiniteDuration,
+  val stsAssumeRole: Option[STSAssumeRoleSettings]
 )
 
 object KinesisConsumerSettings {
   def apply(
-      streamName: String,
-      appName: String,
-      region: Region = Region.US_EAST_1,
-      maxConcurrency: Int = Int.MaxValue,
-      bufferSize: Int = 10,
-      terminateGracePeriod: FiniteDuration = 10.seconds,
-      stsAssumeRole: Option[STSAssumeRoleSettings] = None
+    streamName: String,
+    appName: String,
+    region: Region = Region.US_EAST_1,
+    maxConcurrency: Int = Int.MaxValue,
+    bufferSize: Int = 10,
+    terminateGracePeriod: FiniteDuration = 10.seconds,
+    stsAssumeRole: Option[STSAssumeRoleSettings] = None
   ): Either[Throwable, KinesisConsumerSettings] =
     (bufferSize, maxConcurrency, terminateGracePeriod) match {
       case (bs, _, _) if bs < 1 => Left(BufferSizeException("Must be greater than 0"))
@@ -56,8 +56,8 @@ object KinesisConsumerSettings {
   * @param roleSessionName An identifier for the assumed role session.
   */
 class STSAssumeRoleSettings private (
-    val roleArn: String,
-    val roleSessionName: String
+  val roleArn: String,
+  val roleSessionName: String
 )
 
 object STSAssumeRoleSettings {
@@ -71,21 +71,26 @@ object STSAssumeRoleSettings {
   *  @param maxBatchWait the maximum amount of time to wait before checkpointing the cluster of records
   */
 class KinesisCheckpointSettings private (
-    val maxBatchSize: Int,
-    val maxBatchWait: FiniteDuration
+  val maxBatchSize: Int,
+  val maxBatchWait: FiniteDuration
 )
 
 object KinesisCheckpointSettings {
   val defaultInstance = new KinesisCheckpointSettings(1000, 10.seconds)
 
-  def apply(maxBatchSize: Int,
-            maxBatchWait: FiniteDuration): Either[Throwable, KinesisCheckpointSettings] =
+  def apply(
+    maxBatchSize: Int,
+    maxBatchWait: FiniteDuration
+  ): Either[Throwable, KinesisCheckpointSettings] =
     (maxBatchSize, maxBatchWait) match {
       case (s, _) if s <= 0 =>
         Left(MaxBatchSizeException("Must be greater than 0"))
       case (_, w) if w <= 0.milliseconds =>
-        Left(MaxBatchWaitException(
-          "Must be greater than 0 milliseconds. To checkpoint immediately, pass 1 to the max batch size."))
+        Left(
+          MaxBatchWaitException(
+            "Must be greater than 0 milliseconds. To checkpoint immediately, pass 1 to the max batch size."
+          )
+        )
       case (s, w) =>
         Right(new KinesisCheckpointSettings(s, w))
     }

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/SingleRecordProcessor.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/SingleRecordProcessor.scala
@@ -12,10 +12,11 @@ import scala.concurrent.duration.FiniteDuration
   *  @constructor create a new instance with a callback function to perform on record receive
   *  @param cb callback function to run on record receive, passing the new CommittableRecord
   */
-private[aws] class SingleRecordProcessor(cb: CommittableRecord => Unit,
-                                         override val terminateGracePeriod: FiniteDuration)
-    extends RecordProcessor {
-  override def processRecords(processRecordsInput: ProcessRecordsInput): Unit = {
+private[aws] class SingleRecordProcessor(
+  cb: CommittableRecord => Unit,
+  override val terminateGracePeriod: FiniteDuration
+) extends RecordProcessor {
+  override def processRecords(processRecordsInput: ProcessRecordsInput): Unit =
     processRecordsInput.records().asScala.foreach { record =>
       cb(
         CommittableRecord(
@@ -28,5 +29,4 @@ private[aws] class SingleRecordProcessor(cb: CommittableRecord => Unit,
         )
       )
     }
-  }
 }

--- a/fs2-aws/src/main/scala/fs2/aws/s3/package.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/s3/package.scala
@@ -1,11 +1,11 @@
 package fs2.aws
 
-import java.io.{ByteArrayInputStream, InputStream}
+import java.io.{ ByteArrayInputStream, InputStream }
 
-import cats.effect.{Blocker, ContextShift, Effect}
+import cats.effect.{ Blocker, ContextShift, Effect }
 import cats.implicits._
 import com.amazonaws.services.s3.model._
-import fs2.{Chunk, Pull, Stream}
+import fs2.{ Chunk, Pull, Stream }
 import fs2.io.readInputStream
 import fs2.aws.internal._
 
@@ -14,14 +14,18 @@ import scala.concurrent.ExecutionContext
 
 package object s3 {
   def readS3FileMultipart[F[_]](
-      bucket: String,
-      key: String,
-      chunkSize: Int,
-      s3Client: S3Client[F] = new S3Client[F] {})(implicit F: Effect[F]): Stream[F, Byte] = {
+    bucket: String,
+    key: String,
+    chunkSize: Int,
+    s3Client: S3Client[F] = new S3Client[F] {}
+  )(implicit F: Effect[F]): Stream[F, Byte] = {
     def go(offset: Int)(implicit F: Effect[F]): Pull[F, Byte, Unit] =
       fs2.Stream
-        .bracket[F, Either[Throwable, InputStream]](s3Client.getObjectContentOrError(
-          new GetObjectRequest(bucket, key).withRange(offset, offset + chunkSize))) {
+        .bracket[F, Either[Throwable, InputStream]](
+          s3Client.getObjectContentOrError(
+            new GetObjectRequest(bucket, key).withRange(offset, offset + chunkSize)
+          )
+        ) {
           case Left(e)  => F.raiseError(e)
           case Right(s) => F.delay(s.close())
         }
@@ -46,24 +50,26 @@ package object s3 {
 
   }
 
-  def readS3File[F[_]](bucket: String,
-                       key: String,
-                       blockingEC: ExecutionContext,
-                       s3Client: S3Client[F] = new S3Client[F] {})(
-      implicit F: Effect[F],
-      cs: ContextShift[F]): Stream[F, Byte] = {
-    readInputStream[F](s3Client.getObjectContent(new GetObjectRequest(bucket, key)),
-                       chunkSize = 8192,
-                       blocker = Blocker.liftExecutionContext(blockingEC),
-                       closeAfterUse = true)
-  }
+  def readS3File[F[_]](
+    bucket: String,
+    key: String,
+    blockingEC: ExecutionContext,
+    s3Client: S3Client[F] = new S3Client[F] {}
+  )(implicit F: Effect[F], cs: ContextShift[F]): Stream[F, Byte] =
+    readInputStream[F](
+      s3Client.getObjectContent(new GetObjectRequest(bucket, key)),
+      chunkSize = 8192,
+      blocker = Blocker.liftExecutionContext(blockingEC),
+      closeAfterUse = true
+    )
 
-  def uploadS3FileMultipart[F[_]](bucket: String,
-                                  key: String,
-                                  partSize: Int,
-                                  objectMetadata: Option[ObjectMetadata] = None,
-                                  s3Client: S3Client[F] = new S3Client[F] {})(
-      implicit F: Effect[F]): fs2.Pipe[F, Byte, Unit] = {
+  def uploadS3FileMultipart[F[_]](
+    bucket: String,
+    key: String,
+    partSize: Int,
+    objectMetadata: Option[ObjectMetadata] = None,
+    s3Client: S3Client[F] = new S3Client[F] {}
+  )(implicit F: Effect[F]): fs2.Pipe[F, Byte, Unit] = {
     def uploadPart(uploadId: String): fs2.Pipe[F, (Chunk[Byte], Long), PartETag] =
       _.flatMap({
         case (c, i) =>
@@ -76,40 +82,45 @@ package object s3 {
                   .withUploadId(uploadId)
                   .withPartNumber(i.toInt)
                   .withPartSize(c.size)
-                  .withInputStream(new ByteArrayInputStream(c.toArray)))
-              .flatMap(r => F.delay(r.getPartETag)))
+                  .withInputStream(new ByteArrayInputStream(c.toArray))
+              )
+              .flatMap(r => F.delay(r.getPartETag))
+          )
       })
 
     def completeUpload(uploadId: String): fs2.Pipe[F, List[PartETag], Unit] =
-      _.flatMap(
-        parts =>
-          Stream.eval_(s3Client.completeMultipartUpload(
-            new CompleteMultipartUploadRequest(bucket, key, uploadId, parts.asJava))))
+      _.flatMap(parts =>
+        Stream.eval_(
+          s3Client.completeMultipartUpload(
+            new CompleteMultipartUploadRequest(bucket, key, uploadId, parts.asJava)
+          )
+        )
+      )
 
-    in =>
-      {
-        val imuF: F[InitiateMultipartUploadResult] = objectMetadata match {
-          case Some(o) =>
-            s3Client.initiateMultipartUpload(new InitiateMultipartUploadRequest(bucket, key, o))
-          case None =>
-            s3Client.initiateMultipartUpload(new InitiateMultipartUploadRequest(bucket, key))
-        }
-        val mui: F[MultiPartUploadInfo] =
-          imuF.flatMap(imu => F.pure(MultiPartUploadInfo(imu.getUploadId, List())))
-        Stream
-          .eval(mui)
-          .flatMap(
-            m =>
-              in.chunkN(partSize)
-                .zip(Stream.iterate(1L)(_ + 1))
-                .through(uploadPart(m.uploadId))
-                .fold[List[PartETag]](List())(_ :+ _)
-                .through(completeUpload(m.uploadId)))
+    in => {
+      val imuF: F[InitiateMultipartUploadResult] = objectMetadata match {
+        case Some(o) =>
+          s3Client.initiateMultipartUpload(new InitiateMultipartUploadRequest(bucket, key, o))
+        case None =>
+          s3Client.initiateMultipartUpload(new InitiateMultipartUploadRequest(bucket, key))
       }
+      val mui: F[MultiPartUploadInfo] =
+        imuF.flatMap(imu => F.pure(MultiPartUploadInfo(imu.getUploadId, List())))
+      Stream
+        .eval(mui)
+        .flatMap(m =>
+          in.chunkN(partSize)
+            .zip(Stream.iterate(1L)(_ + 1))
+            .through(uploadPart(m.uploadId))
+            .fold[List[PartETag]](List())(_ :+ _)
+            .through(completeUpload(m.uploadId))
+        )
+    }
   }
 
   def listFiles[F[_]](bucketName: String, s3Client: S3Client[F] = new S3Client[F] {})(
-      implicit F: Effect[F]): Stream[F, S3ObjectSummary] = {
+    implicit F: Effect[F]
+  ): Stream[F, S3ObjectSummary] = {
     val req = new ListObjectsV2Request().withBucketName(bucketName)
     Stream.eval(s3Client.s3ObjectSummaries(req)).flatMap(list => Stream.emits(list))
   }

--- a/fs2-aws/src/main/scala/fs2/aws/sqs/ConsumerBuilder.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/sqs/ConsumerBuilder.scala
@@ -6,9 +6,8 @@ import cats.effect.Effect
 trait ConsumerBuilder[F[_]] {
   def start: F[SQSConsumer]
 
-  def serve[A](stream: fs2.Stream[F, A])(implicit F: Effect[F]): fs2.Stream[F, A] = {
+  def serve[A](stream: fs2.Stream[F, A])(implicit F: Effect[F]): fs2.Stream[F, A] =
     fs2.Stream
       .bracket(start)(con => F.delay(con.shutdown()))
       .flatMap(con => Stream.eval(F.delay(con.startConsumer())).drain ++ stream)
-  }
 }

--- a/fs2-aws/src/main/scala/fs2/aws/sqs/ReceiverCallback.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/sqs/ReceiverCallback.scala
@@ -1,17 +1,16 @@
 package fs2.aws.sqs
 
-import javax.jms.{Message, MessageListener}
+import javax.jms.{ Message, MessageListener }
 
 import cats.syntax.either._
 import scala.util.control.Exception
 
 class ReceiverCallback[A](f: A => Unit)(implicit messageParser: Message => A)
     extends MessageListener {
-  def onMessage(message: Message): Unit = {
+  def onMessage(message: Message): Unit =
     Exception.nonFatalCatch either {
       messageParser.andThen(f)(message)
       message.acknowledge()
     } leftMap (e => System.err.println("Error processing message: " + e.getMessage))
-  }
 
 }

--- a/fs2-aws/src/main/scala/fs2/aws/sqs/SQSConsumerBuilder.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/sqs/SQSConsumerBuilder.scala
@@ -1,16 +1,16 @@
 package fs2.aws.sqs
 
 import cats.effect.Effect
-import com.amazon.sqs.javamessaging.{ProviderConfiguration, SQSConnection, SQSConnectionFactory}
+import com.amazon.sqs.javamessaging.{ ProviderConfiguration, SQSConnection, SQSConnectionFactory }
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import eu.timepit.refined.auto._
-import javax.jms.{MessageListener, Session}
+import javax.jms.{ MessageListener, Session }
 
 import scala.language.higherKinds
 
 class SQSConsumerBuilder[F[_]](val sqsConfig: SqsConfig, val listener: MessageListener)(
-    implicit F: Effect[F])
-    extends ConsumerBuilder[F] {
+  implicit F: Effect[F]
+) extends ConsumerBuilder[F] {
 
   val start: F[SQSConsumer] = {
     F.delay {
@@ -30,9 +30,8 @@ class SQSConsumerBuilder[F[_]](val sqsConfig: SqsConfig, val listener: MessageLi
           connection.start()
         }
 
-        override def shutdown(): Unit = {
+        override def shutdown(): Unit =
           connection.stop()
-        }
       }
     }
   }
@@ -40,5 +39,6 @@ class SQSConsumerBuilder[F[_]](val sqsConfig: SqsConfig, val listener: MessageLi
 
 object SQSConsumerBuilder {
   def apply[F[_]](sqsConfig: SqsConfig, listener: MessageListener)(
-      implicit F: Effect[F]): SQSConsumerBuilder[F] = new SQSConsumerBuilder[F](sqsConfig, listener)
+    implicit F: Effect[F]
+  ): SQSConsumerBuilder[F] = new SQSConsumerBuilder[F](sqsConfig, listener)
 }

--- a/fs2-aws/src/main/scala/fs2/aws/sqs/package.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/sqs/package.scala
@@ -1,31 +1,33 @@
 package fs2
 
 import cats.effect.concurrent.Deferred
-import cats.effect.{ConcurrentEffect, IO}
-import fs2.aws.sqs.{ConsumerBuilder, ReceiverCallback, SqsConfig}
+import cats.effect.{ ConcurrentEffect, IO }
+import fs2.aws.sqs.{ ConsumerBuilder, ReceiverCallback, SqsConfig }
 import fs2.concurrent.Queue
-import javax.jms.{Message, MessageListener}
+import javax.jms.{ Message, MessageListener }
 
 package object aws {
 
-  def sqsStream[F[_], O](sqsConfig: SqsConfig,
-                         builder: (SqsConfig, MessageListener) => ConsumerBuilder[F],
-                         d: Option[Deferred[F, MessageListener]] = None)(
-      implicit F: ConcurrentEffect[F],
-      decoder: Message => Either[Throwable, O]): fs2.Stream[F, O] = {
+  def sqsStream[F[_], O](
+    sqsConfig: SqsConfig,
+    builder: (SqsConfig, MessageListener) => ConsumerBuilder[F],
+    d: Option[Deferred[F, MessageListener]] = None
+  )(implicit F: ConcurrentEffect[F], decoder: Message => Either[Throwable, O]): fs2.Stream[F, O] =
     for {
       q        <- fs2.Stream.eval(Queue.unbounded[F, Either[Throwable, O]])
       callback <- fs2.Stream.eval(callback(q))
       _        <- fs2.Stream.eval(d.map(_.complete(callback)).getOrElse(F.unit))
       item     <- builder(sqsConfig, callback).serve(q.dequeue.rethrow)
     } yield item
-  }
 
   def callback[F[_], O](queue: Queue[F, Either[Throwable, O]])(
-      implicit F: ConcurrentEffect[F],
-      decoder: Message => Either[Throwable, O]): F[ReceiverCallback[Either[Throwable, O]]] = {
-    F.delay(new ReceiverCallback[Either[Throwable, O]](r =>
-      F.runAsync(queue.enqueue1(r))(_ => IO.unit).unsafeRunSync()))
-  }
+    implicit F: ConcurrentEffect[F],
+    decoder: Message => Either[Throwable, O]
+  ): F[ReceiverCallback[Either[Throwable, O]]] =
+    F.delay(
+      new ReceiverCallback[Either[Throwable, O]](
+        r => F.runAsync(queue.enqueue1(r))(_ => IO.unit).unsafeRunSync()
+      )
+    )
 
 }

--- a/fs2-aws/src/test/scala/fs2/aws/InternalSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/InternalSpec.scala
@@ -3,11 +3,12 @@ package fs2.aws
 import fs2.Stream
 import cats.effect.{ContextShift, IO}
 import fs2.aws.internal._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
-class InternalSpec extends FlatSpec with Matchers {
+class InternalSpec extends AnyFlatSpec with Matchers {
   implicit val ec: ExecutionContext             = ExecutionContext.global
   implicit val ioContextShift: ContextShift[IO] = IO.contextShift(ec)
 

--- a/fs2-aws/src/test/scala/fs2/aws/InternalSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/InternalSpec.scala
@@ -1,7 +1,7 @@
 package fs2.aws
 
 import fs2.Stream
-import cats.effect.{ContextShift, IO}
+import cats.effect.{ ContextShift, IO }
 import fs2.aws.internal._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -45,7 +45,7 @@ class InternalSpec extends AnyFlatSpec with Matchers {
       .toVector
       .unsafeRunSync
 
-    streams.size shouldBe 1
+    streams.size        shouldBe 1
     streams.head.isLeft shouldBe true
   }
 }

--- a/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
@@ -4,9 +4,14 @@ import java.nio.ByteBuffer
 import java.time.Instant
 import java.util.concurrent.Semaphore
 
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.{ ContextShift, IO, Timer }
 import fs2.aws.kinesis.consumer._
-import fs2.aws.kinesis.{CommittableRecord, KinesisCheckpointSettings, KinesisConsumerSettings, SingleRecordProcessor}
+import fs2.aws.kinesis.{
+  CommittableRecord,
+  KinesisCheckpointSettings,
+  KinesisConsumerSettings,
+  SingleRecordProcessor
+}
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.scalatest.concurrent.Eventually
@@ -18,15 +23,19 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.kinesis.checkpoint.ShardRecordProcessorCheckpointer
 import software.amazon.kinesis.coordinator.Scheduler
 import software.amazon.kinesis.lifecycle.events._
-import software.amazon.kinesis.processor.{ShardRecordProcessor, ShardRecordProcessorFactory}
+import software.amazon.kinesis.processor.{ ShardRecordProcessor, ShardRecordProcessorFactory }
 import software.amazon.kinesis.retrieval.KinesisClientRecord
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
-class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach with Eventually {
+class KinesisConsumerSpec
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterEach
+    with Eventually {
 
   implicit val ec: ExecutionContext             = ExecutionContext.global
   implicit val timer: Timer[IO]                 = IO.timer(ec)
@@ -38,7 +47,7 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
     PatienceConfig(timeout = scaled(Span(2, Seconds)), interval = scaled(Span(5, Millis)))
 
   "KinesisWorker source" should "successfully read data from the Kinesis stream" in new WorkerContext
-  with TestData {
+    with TestData {
     semaphore.acquire()
     recordProcessor.initialize(initializationInput)
     recordProcessor.processRecords(recordsInput.build())
@@ -50,14 +59,14 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
       commitableRecord.record.data() should be(record.data())
       commitableRecord.recordProcessorStartingSequenceNumber shouldBe initializationInput
         .extendedSequenceNumber()
-      commitableRecord.shardId shouldBe initializationInput.shardId()
+      commitableRecord.shardId            shouldBe initializationInput.shardId()
       commitableRecord.millisBehindLatest shouldBe recordsInput.build().millisBehindLatest()
     }
     semaphore.release()
   }
 
   it should "not shutdown the worker if the stream is drained but has not failed" in new WorkerContext
-  with TestData {
+    with TestData {
     semaphore.acquire()
     recordProcessor.initialize(initializationInput)
     recordProcessor.processRecords(recordsInput.records(List(record)).build())
@@ -67,7 +76,7 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
   }
 
   it should "shutdown the worker if the stream terminates" in new WorkerContext(errorStream = true)
-  with TestData {
+    with TestData {
     semaphore.acquire()
     recordProcessor.initialize(initializationInput)
     recordProcessor.processRecords(recordsInput.records(List(record)).build())
@@ -102,7 +111,7 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
   }
 
   it should "not drop messages in case of back-pressure with multiple shard workers" in new WorkerContext
-  with TestData {
+    with TestData {
     semaphore.acquire()
     recordProcessor.initialize(initializationInput)
     recordProcessor2.initialize(
@@ -110,7 +119,8 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
         .builder()
         .shardId("shard2")
         .extendedSequenceNumber(ExtendedSequenceNumber.AT_TIMESTAMP)
-        .build())
+        .build()
+    )
 
     // Create and send 10 records (to match buffer size)
     for (i <- 1 to 5) {
@@ -125,7 +135,7 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
 
     // Each shard is assigned its own worker thread, so we get messages
     // from each thread simultaneously.
-    def simulateWorkerThread(rp: ShardRecordProcessor): Future[Unit] = {
+    def simulateWorkerThread(rp: ShardRecordProcessor): Future[Unit] =
       Future {
         for (i <- 1 to 25) { // 10 is a buffer size
           val record = mock(classOf[KinesisClientRecord])
@@ -133,7 +143,6 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
           rp.processRecords(recordsInput.records(List(record)).build())
         }
       }
-    }
 
     simulateWorkerThread(recordProcessor)
     simulateWorkerThread(recordProcessor2)
@@ -161,8 +170,8 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
     startStream(input)
 
     eventually(timeout(1.second)) {
-      verify(checkpointerShard1).checkpoint(input.last.record.sequenceNumber(),
-                                            input.last.record.subSequenceNumber())
+      verify(checkpointerShard1)
+        .checkpoint(input.last.record.sequenceNumber(), input.last.record.subSequenceNumber())
     }
   }
 
@@ -198,10 +207,10 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
     startStream(input)
 
     eventually(timeout(3.seconds)) {
-      verify(checkpointerShard1).checkpoint(input(2).record.sequenceNumber(),
-                                            input(2).record.subSequenceNumber())
-      verify(checkpointerShard2).checkpoint(input.last.record.sequenceNumber(),
-                                            input.last.record.subSequenceNumber())
+      verify(checkpointerShard1)
+        .checkpoint(input(2).record.sequenceNumber(), input(2).record.subSequenceNumber())
+      verify(checkpointerShard2)
+        .checkpoint(input.last.record.sequenceNumber(), input.last.record.subSequenceNumber())
     }
 
   }
@@ -255,8 +264,9 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
       .unsafeRunSync should have message "you have no power here"
 
     eventually(
-      verify(checkpointer).checkpoint(input.record.sequenceNumber(),
-                                      input.record.subSequenceNumber()))
+      verify(checkpointer)
+        .checkpoint(input.record.sequenceNumber(), input.record.subSequenceNumber())
+    )
   }
 
   it should "bypass all items when checkpoint" in new KinesisWorkerCheckpointContext {
@@ -265,16 +275,16 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
     val record = mock(classOf[KinesisClientRecord])
     when(record.sequenceNumber()).thenReturn("1")
 
-    val input = (1 to 100).map(
-      idx =>
-        new CommittableRecord(
-          s"shard-1",
-          mock(classOf[ExtendedSequenceNumber]),
-          idx,
-          record,
-          recordProcessor,
-          checkpointer
-      ))
+    val input = (1 to 100).map(idx =>
+      new CommittableRecord(
+        s"shard-1",
+        mock(classOf[ExtendedSequenceNumber]),
+        idx,
+        record,
+        recordProcessor,
+        checkpointer
+      )
+    )
 
     fs2.Stream
       .emits(input)
@@ -284,8 +294,10 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
       .unsafeRunSync should have size 100
   }
 
-  private abstract class WorkerContext(backpressureTimeout: FiniteDuration = 1.minute,
-                                       errorStream: Boolean = false) {
+  abstract private class WorkerContext(
+    backpressureTimeout: FiniteDuration = 1.minute,
+    errorStream: Boolean = false
+  ) {
 
     val semaphore = new Semaphore(1)
     semaphore.acquire()
@@ -323,7 +335,8 @@ class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
 
   private trait TestData {
     protected val checkpointer: ShardRecordProcessorCheckpointer = mock(
-      classOf[ShardRecordProcessorCheckpointer])
+      classOf[ShardRecordProcessorCheckpointer]
+    )
 
     val initializationInput = {
       InitializationInput

--- a/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
@@ -6,17 +6,14 @@ import java.util.concurrent.Semaphore
 
 import cats.effect.{ContextShift, IO, Timer}
 import fs2.aws.kinesis.consumer._
-import fs2.aws.kinesis.{
-  CommittableRecord,
-  KinesisCheckpointSettings,
-  KinesisConsumerSettings,
-  SingleRecordProcessor
-}
+import fs2.aws.kinesis.{CommittableRecord, KinesisCheckpointSettings, KinesisConsumerSettings, SingleRecordProcessor}
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.time._
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.regions.Region
 import software.amazon.kinesis.checkpoint.ShardRecordProcessorCheckpointer
 import software.amazon.kinesis.coordinator.Scheduler
@@ -29,7 +26,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
-class KinesisConsumerSpec extends FlatSpec with Matchers with BeforeAndAfterEach with Eventually {
+class KinesisConsumerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach with Eventually {
 
   implicit val ec: ExecutionContext             = ExecutionContext.global
   implicit val timer: Timer[IO]                 = IO.timer(ec)

--- a/fs2-aws/src/test/scala/fs2/aws/KinesisProducerSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/KinesisProducerSpec.scala
@@ -3,8 +3,8 @@ package aws
 
 import java.nio.ByteBuffer
 
-import cats.effect.{ContextShift, IO, Timer}
-import com.amazonaws.services.kinesis.producer.{Attempt, UserRecordResult}
+import cats.effect.{ ContextShift, IO, Timer }
+import com.amazonaws.services.kinesis.producer.{ Attempt, UserRecordResult }
 import com.google.common.util.concurrent.SettableFuture
 import fs2.aws.kinesis.publisher._
 import fs2.aws.utils.KinesisStub
@@ -38,13 +38,14 @@ class KinesisProducerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
       .eval(IO.pure("someData"))
       .flatMap(i => fs2.Stream.emit(("partitionKey", ByteBuffer.wrap(i.getBytes))))
       .through(
-        writeToKinesis[IO]("test-stream", producer = TestKinesisProducerClient[IO](result, ops)))
+        writeToKinesis[IO]("test-stream", producer = TestKinesisProducerClient[IO](result, ops))
+      )
       .attempt
       .compile
       .toVector
       .unsafeRunSync
 
-    output.size should be(1)
+    output.size         should be(1)
     output.head.isRight should be(true)
 
     KinesisStub._data.size should be(1)
@@ -56,7 +57,8 @@ class KinesisProducerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
       .eval(IO.pure("someData"))
       .flatMap(i => fs2.Stream.emit(("partitionKey", ByteBuffer.wrap(i.getBytes))))
       .through(
-        writeToKinesis_[IO]("test-stream", producer = TestKinesisProducerClient[IO](result, ops)))
+        writeToKinesis_[IO]("test-stream", producer = TestKinesisProducerClient[IO](result, ops))
+      )
       .compile
       .toVector
       .unsafeRunSync
@@ -71,15 +73,18 @@ class KinesisProducerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
       .eval(IO.pure("someData"))
       .flatMap(i => fs2.Stream.emit(("partitionKey", i)))
       .through(
-        writeObjectToKinesis[IO, String]("test-stream",
-                                         producer = TestKinesisProducerClient[IO](result, ops)))
+        writeObjectToKinesis[IO, String](
+          "test-stream",
+          producer = TestKinesisProducerClient[IO](result, ops)
+        )
+      )
       .compile
       .toVector
       .unsafeRunSync
 
     KinesisStub._data.size should be(1)
     KinesisStub._data.head should be(ByteBuffer.wrap("someData".getBytes))
-    res should be(Vector("someData" -> result))
+    res                    should be(Vector("someData" -> result))
   }
 
   "error thrown when invoking writeToKinesis" should "return an error in the stream" in new KinesisProducerTestContext {
@@ -90,14 +95,15 @@ class KinesisProducerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
       .through(
         writeToKinesis[IO]("test-stream", producer = TestKinesisProducerClient[IO](result, IO {
           throw new Exception("couldn't connect to kinesis")
-        })))
+        }))
+      )
       .attempt
       .compile
       .toVector
       .unsafeRunSync
 
-    output.size should be(1)
-    output.head.isLeft should be(true)
+    output.size                     should be(1)
+    output.head.isLeft              should be(true)
     output.head.left.get.getMessage should be("couldn't connect to kinesis")
   }
 
@@ -109,7 +115,8 @@ class KinesisProducerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
         .through(
           writeToKinesis_[IO]("test-stream", producer = TestKinesisProducerClient[IO](result, IO {
             throw new Exception("couldn't connect to kinesis")
-          })))
+          }))
+        )
         .compile
         .toVector
         .unsafeRunSync

--- a/fs2-aws/src/test/scala/fs2/aws/KinesisProducerSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/KinesisProducerSpec.scala
@@ -8,12 +8,14 @@ import com.amazonaws.services.kinesis.producer.{Attempt, UserRecordResult}
 import com.google.common.util.concurrent.SettableFuture
 import fs2.aws.kinesis.publisher._
 import fs2.aws.utils.KinesisStub
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
-class KinesisProducerSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
+class KinesisProducerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
   override def beforeEach {
     KinesisStub.clear()
   }

--- a/fs2-aws/src/test/scala/fs2/aws/S3Spec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/S3Spec.scala
@@ -6,11 +6,12 @@ import java.util.concurrent.Executors
 import cats.effect.{ContextShift, IO}
 import fs2.aws.s3._
 import fs2.aws.utils._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
-class S3Spec extends FlatSpec with Matchers {
+class S3Spec extends AnyFlatSpec with Matchers {
 
   private val blockingEC                        = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(6))
   implicit val ec: ExecutionContext             = ExecutionContext.global

--- a/fs2-aws/src/test/scala/fs2/aws/S3Spec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/S3Spec.scala
@@ -3,7 +3,7 @@ package aws
 
 import java.util.concurrent.Executors
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.{ ContextShift, IO }
 import fs2.aws.s3._
 import fs2.aws.utils._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -19,7 +19,8 @@ class S3Spec extends AnyFlatSpec with Matchers {
 
   ignore should "stdout the jsonfile" in {
     readS3FileMultipart[IO]("resources", "jsontest.json", 25, s3TestClient).compile.toVector.unsafeRunSync should be(
-      Vector())
+      Vector()
+    )
   }
 
   "Downloading the JSON test file by chunks" should "return the same content" in {
@@ -31,7 +32,8 @@ class S3Spec extends AnyFlatSpec with Matchers {
       .unsafeRunSync
       .reduce(_ + _)
       .concat("") should be(
-      """{"test": 1}{"test": 2}{"test": 3}{"test": 4}{"test": 5}{"test": 6}{"test": 7}{"test": 8}""")
+      """{"test": 1}{"test": 2}{"test": 3}{"test": 4}{"test": 5}{"test": 6}{"test": 7}{"test": 8}"""
+    )
   }
 
   "Downloading the JSON test file" should "return the same content" in {
@@ -43,7 +45,8 @@ class S3Spec extends AnyFlatSpec with Matchers {
       .unsafeRunSync
       .reduce(_ + _)
       .concat("") should be(
-      """{"test": 1}{"test": 2}{"test": 3}{"test": 4}{"test": 5}{"test": 6}{"test": 7}{"test": 8}""")
+      """{"test": 1}{"test": 2}{"test": 3}{"test": 4}{"test": 5}{"test": 6}{"test": 7}{"test": 8}"""
+    )
   }
 
   "big chunk size but small entire text" should "be trimmed to content" in {

--- a/fs2-aws/src/test/scala/fs2/aws/SqsSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/SqsSpec.scala
@@ -1,13 +1,13 @@
 package fs2.aws
 
 import cats.effect.concurrent.Deferred
-import cats.effect.{ContextShift, IO}
+import cats.effect.{ ContextShift, IO }
 import com.amazon.sqs.javamessaging.SQSConnection
 import com.amazon.sqs.javamessaging.message.SQSTextMessage
 import eu.timepit.refined.auto._
 import fs2.aws
-import fs2.aws.sqs.{ConsumerBuilder, SQSConsumer, SqsConfig}
-import javax.jms.{Message, MessageListener, TextMessage}
+import fs2.aws.sqs.{ ConsumerBuilder, SQSConsumer, SqsConfig }
+import javax.jms.{ Message, MessageListener, TextMessage }
 import org.mockito.scalatest.MockitoSugar
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -28,7 +28,7 @@ class SqsSpec extends AsyncFlatSpec with Matchers with MockitoSugar {
       aws
         .sqsStream[IO, Int](
           SqsConfig("dummy"),
-          (_, listener) => {
+          (_, listener) =>
             new ConsumerBuilder[IO] {
               override def start: IO[SQSConsumer] =
                 IO.delay(new SQSConsumer {
@@ -40,8 +40,7 @@ class SqsSpec extends AsyncFlatSpec with Matchers with MockitoSugar {
 
                   override def connection: SQSConnection = mock[SQSConnection]
                 })
-            }
-          },
+            },
           Some(d)
         )
         .take(4)
@@ -51,15 +50,15 @@ class SqsSpec extends AsyncFlatSpec with Matchers with MockitoSugar {
     val r = for {
       d <- Deferred[IO, MessageListener]
       res <- IO.racePair(stream(d), d.get).flatMap {
-        case Right((streamFiber, listener)) =>
-          listener.onMessage(new SQSTextMessage("1"))
-          listener.onMessage(new SQSTextMessage("2"))
-          listener.onMessage(new SQSTextMessage("fail"))
-          listener.onMessage(new SQSTextMessage("4"))
-          listener.onMessage(new SQSTextMessage("5"))
-          streamFiber.join
-        case _ => IO(Nil)
-      }
+              case Right((streamFiber, listener)) =>
+                listener.onMessage(new SQSTextMessage("1"))
+                listener.onMessage(new SQSTextMessage("2"))
+                listener.onMessage(new SQSTextMessage("fail"))
+                listener.onMessage(new SQSTextMessage("4"))
+                listener.onMessage(new SQSTextMessage("5"))
+                streamFiber.join
+              case _ => IO(Nil)
+            }
     } yield res
 
     val future = r.unsafeToFuture()

--- a/fs2-aws/src/test/scala/fs2/aws/SqsSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/SqsSpec.scala
@@ -8,8 +8,9 @@ import eu.timepit.refined.auto._
 import fs2.aws
 import fs2.aws.sqs.{ConsumerBuilder, SQSConsumer, SqsConfig}
 import javax.jms.{Message, MessageListener, TextMessage}
-import org.scalatest.{AsyncFlatSpec, Matchers}
-import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.scalatest.MockitoSugar
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 

--- a/fs2-aws/src/test/scala/fs2/aws/TestKinesisProducerClient.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/TestKinesisProducerClient.scala
@@ -8,11 +8,13 @@ import com.google.common.util.concurrent.ListenableFuture
 import fs2.aws.internal.KinesisProducerClient
 import fs2.aws.utils.KinesisStub
 
-case class TestKinesisProducerClient[F[_]](respondWith: UserRecordResult,
-                                           ops: F[ListenableFuture[UserRecordResult]])
-    extends KinesisProducerClient[F] {
+case class TestKinesisProducerClient[F[_]](
+  respondWith: UserRecordResult,
+  ops: F[ListenableFuture[UserRecordResult]]
+) extends KinesisProducerClient[F] {
   override def putData(streamName: String, partitionKey: String, data: ByteBuffer)(
-      implicit e: Sync[F]): F[ListenableFuture[UserRecordResult]] = {
+    implicit e: Sync[F]
+  ): F[ListenableFuture[UserRecordResult]] = {
     KinesisStub.save(data)
     ops
   }

--- a/fs2-aws/src/test/scala/fs2/aws/utils/KinesisStub.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/utils/KinesisStub.scala
@@ -7,7 +7,6 @@ object KinesisStub {
 
   def clear() = _data = List()
 
-  def save(data: ByteBuffer) = {
+  def save(data: ByteBuffer) =
     _data = _data :+ data
-  }
 }

--- a/fs2-aws/src/test/scala/fs2/aws/utils/package.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/utils/package.scala
@@ -4,6 +4,7 @@ import java.io._
 
 import cats.effect.{ Effect, IO }
 import com.amazonaws.SdkClientException
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{ AmazonS3Exception, GetObjectRequest, S3ObjectInputStream }
 import fs2.aws.internal._
 import org.apache.http.client.methods.HttpRequestBase
@@ -11,6 +12,10 @@ import scala.io.Source
 
 package object utils {
   val s3TestClient: S3Client[IO] = new S3Client[IO] {
+
+    override def client: AmazonS3 =
+      throw new NotImplementedError("s3 client shouldn't be used in this test client")
+
     override def getObjectContentOrError(
       getObjectRequest: GetObjectRequest
     )(implicit e: Effect[IO]): IO[Either[Throwable, InputStream]] =

--- a/fs2-aws/src/test/scala/fs2/aws/utils/package.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/utils/package.scala
@@ -2,17 +2,18 @@ package fs2.aws
 
 import java.io._
 
-import cats.effect.{Effect, IO}
+import cats.effect.{ Effect, IO }
 import com.amazonaws.SdkClientException
-import com.amazonaws.services.s3.model.{AmazonS3Exception, GetObjectRequest, S3ObjectInputStream}
+import com.amazonaws.services.s3.model.{ AmazonS3Exception, GetObjectRequest, S3ObjectInputStream }
 import fs2.aws.internal._
 import org.apache.http.client.methods.HttpRequestBase
 import scala.io.Source
 
 package object utils {
   val s3TestClient: S3Client[IO] = new S3Client[IO] {
-    override def getObjectContentOrError(getObjectRequest: GetObjectRequest)(
-        implicit e: Effect[IO]): IO[Either[Throwable, InputStream]] =
+    override def getObjectContentOrError(
+      getObjectRequest: GetObjectRequest
+    )(implicit e: Effect[IO]): IO[Either[Throwable, InputStream]] =
       getObjectRequest match {
         case goe: GetObjectRequest => {
           IO[Either[Throwable, ByteArrayInputStream]] {
@@ -42,8 +43,9 @@ package object utils {
         case _ => throw new SdkClientException("Invalid GetObjectRequest")
       }
 
-    override def getObjectContent(getObjectRequest: GetObjectRequest)(
-        implicit e: Effect[IO]): IO[InputStream] =
+    override def getObjectContent(
+      getObjectRequest: GetObjectRequest
+    )(implicit e: Effect[IO]): IO[InputStream] =
       IO[ByteArrayInputStream] {
         val fileContent: Array[Byte] =
           try {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // scala format
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.1")
 
 // coverage
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")


### PR DESCRIPTION
I think the `S3Client` internal class should go away altogether from consumer visibility, but for now it's been relegated to a default implicit.