### PR TITLE
Allow AmazonS3 client to be passed in

### DIFF
--- a/fs2-aws/src/main/scala/fs2/aws/internal/S3Client.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/internal/S3Client.scala
@@ -3,14 +3,23 @@ package fs2.aws.internal
 import java.io.InputStream
 
 import cats.effect.Effect
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model._
 
 import scala.collection.JavaConverters._
 import scala.util.control.Exception
 
+private[aws] object S3Client {
+  def apply[F[_]](s3: AmazonS3) = new S3ClientImpl[F](s3)
+}
+
+private[aws] class S3ClientImpl[F[_]](c: AmazonS3) extends S3Client[F] {
+  override def client: AmazonS3 = c
+}
+
 private[aws] trait S3Client[F[_]] {
-  private lazy val client = AmazonS3ClientBuilder.defaultClient
+
+  def client: AmazonS3
 
   def getObjectContentOrError(
     getObjectRequest: GetObjectRequest

--- a/fs2-aws/src/test/scala/fs2/aws/utils/package.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/utils/package.scala
@@ -4,6 +4,7 @@ import java.io._
 
 import cats.effect.{ Effect, IO }
 import com.amazonaws.SdkClientException
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{ AmazonS3Exception, GetObjectRequest, S3ObjectInputStream }
 import fs2.aws.internal._
 import org.apache.http.client.methods.HttpRequestBase
@@ -11,6 +12,10 @@ import scala.io.Source
 
 package object utils {
   val s3TestClient: S3Client[IO] = new S3Client[IO] {
+
+    override def client: AmazonS3 =
+      throw new NotImplementedError("s3 client shouldn't be used in this test client")
+
     override def getObjectContentOrError(
       getObjectRequest: GetObjectRequest
     )(implicit e: Effect[IO]): IO[Either[Throwable, InputStream]] =


### PR DESCRIPTION
I don't have time to get rid of the 'internal' S3Client that somehow still is on the public signature.  Moved it to an implicit.. 