### PR TITLE
One thread from cats IO default thread pool was permanently allocated…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name         := "fs2-aws"
 scalaVersion := "2.12.10"
 
 val fs2Version    = "2.2.2"
-val AwsSdkVersion = "1.11.737"
+val AwsSdkVersion = "1.11.739"
 val cirisVersion  = "0.12.1"
 val circeVersion  = "0.13.0"
 

--- a/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/package.scala
+++ b/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/package.scala
@@ -1,6 +1,6 @@
 package fs2.aws
 
-import cats.effect.{ Blocker, ConcurrentEffect, ContextShift, Effect, IO, Sync, Timer }
+import cats.effect._
 import cats.implicits._
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.regions.Regions
@@ -112,10 +112,11 @@ package object dynamodb {
 
     // Initialize a KCL worker which appends to the internal stream queue on message receipt
     def instantiateWorker(queue: Queue[F, CommittableRecord]): Stream[F, Worker] = Stream.emit {
-      workerFactory(() =>
-        new RecordProcessor(
-          record => Effect[F].runAsync(queue.enqueue1(record))(_ => IO.unit).unsafeRunSync,
-          streamConfig.terminateGracePeriod
+      workerFactory(
+        () =>
+          new RecordProcessor(
+            record => Effect[F].runAsync(queue.enqueue1(record))(_ => IO.unit).unsafeRunSync,
+            streamConfig.terminateGracePeriod
         )
       )
     }

--- a/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/package.scala
+++ b/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/package.scala
@@ -112,11 +112,10 @@ package object dynamodb {
 
     // Initialize a KCL worker which appends to the internal stream queue on message receipt
     def instantiateWorker(queue: Queue[F, CommittableRecord]): Stream[F, Worker] = Stream.emit {
-      workerFactory(
-        () =>
-          new RecordProcessor(
-            record => Effect[F].runAsync(queue.enqueue1(record))(_ => IO.unit).unsafeRunSync,
-            streamConfig.terminateGracePeriod
+      workerFactory(() =>
+        new RecordProcessor(
+          record => Effect[F].runAsync(queue.enqueue1(record))(_ => IO.unit).unsafeRunSync,
+          streamConfig.terminateGracePeriod
         )
       )
     }


### PR DESCRIPTION
… to Kcl loop.

By default IO thread pool size is driven by number of underling machine CPU cores. Which means if you run your service say on t2.micro, this single thread will be allocated to KCL, the rest of the IO will be stalled forever.
Run kcl loop in separate blocking thread pool.