### PR TITLE
Make Region mandatory and rename Ether-returning apply methods to build

### DIFF
--- a/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/KinesisStreamSettings.scala
+++ b/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/KinesisStreamSettings.scala
@@ -24,20 +24,20 @@ class KinesisCheckpointSettings private (
 object KinesisStreamSettings {
   val defaultInstance: KinesisStreamSettings = new KinesisStreamSettings(10, 10.seconds)
 
-  def apply(
+  def build(
     bufferSize: Int,
     terminateGracePeriod: FiniteDuration
   ): Either[Throwable, KinesisStreamSettings] =
     (bufferSize, terminateGracePeriod) match {
       case (bs, _) if bs < 1 => Left(new RuntimeException("Must be greater than 0"))
-      case (bs, period)      => Right(new KinesisStreamSettings(bufferSize, period))
+      case (_, period)       => Right(new KinesisStreamSettings(bufferSize, period))
     }
 }
 
 object KinesisCheckpointSettings {
   val defaultInstance = new KinesisCheckpointSettings(1000, 10.seconds)
 
-  def apply(
+  def build(
     maxBatchSize: Int,
     maxBatchWait: FiniteDuration
   ): Either[Throwable, KinesisCheckpointSettings] =

--- a/fs2-aws-dynamodb/src/test/scala/fs2/aws/dynamodb/DynamoDBConsumerSpec.scala
+++ b/fs2-aws-dynamodb/src/test/scala/fs2/aws/dynamodb/DynamoDBConsumerSpec.scala
@@ -1,5 +1,4 @@
-package fs2
-package aws
+package fs2.aws
 
 import java.util.Date
 import java.util.concurrent.Semaphore
@@ -312,7 +311,7 @@ class DynamoDBConsumerSpec
       mockWorker
     }
 
-    val config: KinesisStreamSettings = KinesisStreamSettings(bufferSize = 10, 10.seconds).right.get
+    val config: KinesisStreamSettings = KinesisStreamSettings.build(bufferSize = 10, 10.seconds).right.get
 
     val stream: Unit =
       readFromDynamoDBStream[IO](builder, config)
@@ -353,7 +352,7 @@ class DynamoDBConsumerSpec
       classOf[IRecordProcessorCheckpointer]
     )
     val settings: KinesisCheckpointSettings =
-      KinesisCheckpointSettings(maxBatchSize = 100, maxBatchWait = 500.millis).right.get
+      KinesisCheckpointSettings.build(maxBatchSize = 100, maxBatchWait = 500.millis).right.get
 
     def startStream(input: Seq[CommittableRecord]): Unit =
       fs2.Stream

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/KinesisSettings.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/KinesisSettings.scala
@@ -30,10 +30,10 @@ class KinesisConsumerSettings private (
 )
 
 object KinesisConsumerSettings {
-  def apply(
+  def build(
     streamName: String,
     appName: String,
-    region: Region = Region.US_EAST_1,
+    region: Region,
     maxConcurrency: Int = Int.MaxValue,
     bufferSize: Int = 10,
     terminateGracePeriod: FiniteDuration = 10.seconds,
@@ -76,7 +76,7 @@ class STSAssumeRoleSettings private (
 )
 
 object STSAssumeRoleSettings {
-  def apply(roleArn: String, roleSessionName: String) =
+  def apply(roleArn: String, roleSessionName: String): STSAssumeRoleSettings =
     new STSAssumeRoleSettings(roleArn, roleSessionName)
 }
 
@@ -93,7 +93,7 @@ class KinesisCheckpointSettings private (
 object KinesisCheckpointSettings {
   val defaultInstance = new KinesisCheckpointSettings(1000, 10.seconds)
 
-  def apply(
+  def build(
     maxBatchSize: Int,
     maxBatchWait: FiniteDuration
   ): Either[Throwable, KinesisCheckpointSettings] =

--- a/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/KinesisConsumerSpec.scala
@@ -322,7 +322,7 @@ class KinesisConsumerSpec
     }
 
     val config =
-      KinesisConsumerSettings("testStream", "testApp", Region.US_EAST_1, 10, 10, 10.seconds).right.get
+      KinesisConsumerSettings.build("testStream", "testApp", Region.US_EAST_1, 10, 10, 10.seconds).right.get
 
     val stream =
       readFromKinesisStream[IO](config, builder)
@@ -367,7 +367,7 @@ class KinesisConsumerSpec
     val recordProcessor    = new SingleRecordProcessor(_ => (), 1.seconds)
     val checkpointerShard1 = mock(classOf[ShardRecordProcessorCheckpointer])
     val settings =
-      KinesisCheckpointSettings(maxBatchSize = Int.MaxValue, maxBatchWait = 500.millis).right
+      KinesisCheckpointSettings.build(maxBatchSize = Int.MaxValue, maxBatchWait = 500.millis).right
         .getOrElse(throw new Error())
 
     def startStream(input: Seq[CommittableRecord]) =


### PR DESCRIPTION
Hello!

Just two things I found confusing when I first tried to use `fs2-aws`:

1. `Either`-returning constructors. In my (maybe very personal) opinion, `A.apply` should always return object of type `A` and smart constructions should be distinguishable
2. Right now if AWS region is not specified and stream is located in a different one - consumer will start throwing exceptions that we could easily prevent.