### PR TITLE
Changes to enable Kinesis client to work with LocalStack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,5 +20,8 @@ jobs:
         run: docker-compose up -d
       - name: Run tests
         run: csbt +clean +test
+        env:
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
       - name: "Shutting down MinIO 🐳"
         run: docker-compose down

--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ Stream("testData")
 
 AWS credential chain and region can be configured by overriding the respective fields in the KinesisProducerClient parameter to `writeToKinesis`. Defaults to using the default AWS credentials chain and `us-east-1` for region.
 
+### Use with LocalStack
+
+In some situations (e.g. local dev and automated tests), it may be desirable to be able to consume from and publish to Kinesis running inside LocalStack.
+Ensure that the `endpoint` setting is set correctly (e.g. http://localhost:4566) and that `retrievalMode` is set to `Polling` (LocalStack doesn't support `FanOut`).
+
 ## Kinesis Firehose
 **TODO:** Stream get data, Stream send data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,11 @@ services:
     ports:
       - 4566:4566
     environment:
-      - "SERVICES=sqs,sns"
+      - "AWS_ACCESS_KEY_ID=dummy"
+      - "AWS_SECRET_ACCESS_KEY=dummy"
+      - "SERVICES=sqs,sns,kinesis,cloudwatch,dynamodb"
       - "DEFAULT_REGION=us-east-1"
+      - "USE_SSL=true"
+    volumes:
+      - "./scripts/localstack:/docker-entrypoint-initaws.d"
+

--- a/fs2-aws/src/main/scala/fs2/aws/internal/KinesisProducerClient.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/internal/KinesisProducerClient.scala
@@ -1,7 +1,5 @@
 package fs2.aws.internal
 
-import java.nio.ByteBuffer
-
 import cats.effect.Sync
 import com.amazonaws.auth.{ AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain }
 import com.amazonaws.services.kinesis.producer.{
@@ -11,18 +9,21 @@ import com.amazonaws.services.kinesis.producer.{
 }
 import com.google.common.util.concurrent.ListenableFuture
 
+import java.nio.ByteBuffer
+
 trait KinesisProducerClient[F[_]] {
   def putData(streamName: String, partitionKey: String, data: ByteBuffer)(
     implicit F: Sync[F]
   ): F[ListenableFuture[UserRecordResult]]
 }
 
-class KinesisProducerClientImpl[F[_]] extends KinesisProducerClient[F] {
+class KinesisProducerClientImpl[F[_]](config: Option[KinesisProducerConfiguration] = None)
+    extends KinesisProducerClient[F] {
 
   val credentials: AWSCredentialsProviderChain = new DefaultAWSCredentialsProviderChain()
   val region: Option[String]                   = None
 
-  private lazy val config: KinesisProducerConfiguration = {
+  private lazy val defaultConfig: KinesisProducerConfiguration = {
     val c = new KinesisProducerConfiguration()
       .setCredentialsProvider(credentials)
 
@@ -30,7 +31,7 @@ class KinesisProducerClientImpl[F[_]] extends KinesisProducerClient[F] {
     c
   }
 
-  private lazy val client = new KinesisProducer(config)
+  private lazy val client = new KinesisProducer(config.getOrElse(defaultConfig))
 
   override def putData(streamName: String, partitionKey: String, data: ByteBuffer)(
     implicit F: Sync[F]

--- a/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
+++ b/fs2-aws/src/main/scala/fs2/aws/kinesis/consumer.scala
@@ -5,13 +5,13 @@ import java.util.UUID
 import cats.effect.{ Blocker, ConcurrentEffect, ContextShift, IO, Sync, Timer }
 import cats.implicits._
 import fs2.aws.core
-import fs2.{ Chunk, Pipe, RaiseThrowable, Stream }
 import fs2.concurrent.Queue
+import fs2.{ Chunk, Pipe, RaiseThrowable, Stream }
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
-import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
@@ -19,11 +19,15 @@ import software.amazon.kinesis.common.{ ConfigsBuilder, InitialPositionInStreamE
 import software.amazon.kinesis.coordinator.Scheduler
 import software.amazon.kinesis.processor.ShardRecordProcessorFactory
 import software.amazon.kinesis.retrieval.KinesisClientRecord
+import software.amazon.kinesis.retrieval.fanout.FanOutConfig
+import software.amazon.kinesis.retrieval.polling.PollingConfig
 
 object consumer {
-  def mkDefaultKinesisClient(settings: KinesisConsumerSettings): KinesisAsyncClient =
-    KinesisAsyncClient
+  def mkDefaultKinesisClient(settings: KinesisConsumerSettings): KinesisAsyncClient = {
+    val builder = KinesisAsyncClient
       .builder()
+    settings.endpoint.foreach(builder.endpointOverride)
+    builder
       .region(settings.region)
       .credentialsProvider(
         settings.stsAssumeRole
@@ -42,8 +46,13 @@ object consumer {
           )
           .getOrElse(DefaultCredentialsProvider.create())
       )
-      .httpClientBuilder(NettyNioAsyncHttpClient.builder().maxConcurrency(settings.maxConcurrency))
+      .httpClientBuilder(
+        NettyNioAsyncHttpClient
+          .builder()
+          .maxConcurrency(settings.maxConcurrency)
+      )
       .build()
+  }
 
   private def defaultScheduler(
     recordProcessorFactory: ShardRecordProcessorFactory,
@@ -51,10 +60,15 @@ object consumer {
     kinesisClient: KinesisAsyncClient
   ): Scheduler = {
 
+    val dynamoClientBuilder = DynamoDbAsyncClient.builder()
+    settings.endpoint.foreach(dynamoClientBuilder.endpointOverride)
     val dynamoClient: DynamoDbAsyncClient =
-      DynamoDbAsyncClient.builder().region(settings.region).build()
+      dynamoClientBuilder.region(settings.region).build()
+
+    val cloudWatchClientBuilder = CloudWatchAsyncClient.builder()
+    settings.endpoint.foreach(cloudWatchClientBuilder.endpointOverride)
     val cloudWatchClient: CloudWatchAsyncClient =
-      CloudWatchAsyncClient.builder().region(settings.region).build()
+      cloudWatchClientBuilder.region(settings.region).build()
 
     val configsBuilder: ConfigsBuilder = new ConfigsBuilder(
       settings.streamName,
@@ -67,6 +81,12 @@ object consumer {
     )
 
     val retrievalConfig = configsBuilder.retrievalConfig()
+    retrievalConfig.retrievalSpecificConfig(
+      settings.retrievalMode match {
+        case FanOut  => new FanOutConfig(kinesisClient)
+        case Polling => new PollingConfig(settings.streamName, kinesisClient)
+      }
+    )
     retrievalConfig.initialPositionInStreamExtended(
       settings.initialPositionInStream match {
         case Left(position) =>

--- a/fs2-aws/src/test/scala/fs2/aws/kinesis/LocalStackSuite.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/kinesis/LocalStackSuite.scala
@@ -1,0 +1,82 @@
+package fs2.aws.kinesis
+
+import cats.effect.{ ContextShift, IO, Timer }
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration
+import fs2.Stream
+import fs2.aws.internal.KinesisProducerClientImpl
+import fs2.aws.kinesis.consumer.readFromKinesisStream
+import fs2.aws.kinesis.publisher.writeToKinesis
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{ Minutes, Second, Span }
+import software.amazon.kinesis.common.InitialPositionInStream
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import scala.concurrent.ExecutionContext
+
+class LocalStackSuite extends AnyFlatSpec with Matchers with ScalaFutures {
+
+  implicit val ec: ExecutionContext             = ExecutionContext.global
+  implicit val timer: Timer[IO]                 = IO.timer(ec)
+  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(ec)
+
+  implicit override val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = scaled(Span(2, Minutes)), interval = scaled(Span(1, Second)))
+
+  "The Kinesis producer and consumer" should "be able to produce to and consume from LocalStack" in {
+
+    // this is required to make the KCL work with LocalStack
+    System.setProperty("aws.cborEnabled", "false")
+
+    val streamName = "test"
+
+    val consumerConfig = KinesisConsumerSettings(
+      streamName,
+      "test-app",
+      initialPositionInStream = Left(InitialPositionInStream.TRIM_HORIZON),
+      endpoint = Some("http://localhost:4566"),
+      retrievalMode = Polling
+    ).toTry.get
+
+    val producerConfig = new KinesisProducerConfiguration()
+      .setCredentialsProvider(new DefaultAWSCredentialsProviderChain())
+      .setKinesisEndpoint("localhost")
+      .setKinesisPort(4566)
+      .setCloudwatchEndpoint("localhost")
+      .setCloudwatchPort(4566)
+      .setVerifyCertificate(false)
+      .setRegion("us-east-1")
+
+    val partitionKey = "test"
+    val data         = List("foo", "bar", "baz")
+
+    val test = for {
+      _ <- Stream
+            .emits(data)
+            .map(d => (partitionKey, ByteBuffer.wrap(d.getBytes)))
+            .through(
+              writeToKinesis[IO](
+                streamName,
+                producer = new KinesisProducerClientImpl[IO](Some(producerConfig))
+              )
+            )
+            .compile
+            .drain
+      record <- readFromKinesisStream[IO](consumerConfig).take(data.length).compile.toList
+    } yield record
+
+    val records = test.unsafeToFuture().futureValue
+
+    val actualPartitionKeys = records.map(_.record.partitionKey())
+    val actualData          = records.map(deserialiseData)
+    actualPartitionKeys shouldBe (1 to data.length).map(_ => partitionKey)
+    actualData          shouldBe data
+  }
+
+  private def deserialiseData(committable: CommittableRecord) =
+    StandardCharsets.UTF_8.decode(committable.record.data()).toString
+
+}

--- a/scripts/localstack/create-stream.sh
+++ b/scripts/localstack/create-stream.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -x
+awslocal kinesis create-stream --stream-name test --shard-count 1
+set +x


### PR DESCRIPTION
We would like to use the client, but we have a requirement to be able to run end-to-end tests against a containerised stack, which rules out hitting AWS. With these changes, it's possible to override the endpoint that is used by the three clients that are created (Kinesis, DynamoDB, CloudWatch), so it can be set to the LocalStack endpoint (e.g. http://localhost:4566). It is also possible to change the retrieval mode, as the default (FanOut) doesn't work with LocalStack.