### PR TITLE
Fixes integer overflow when reading large files from S3 using readFileMultipart causes OOM

### DIFF
--- a/fs2-aws-s3/src/main/scala/fs2/aws/s3.scala
+++ b/fs2-aws-s3/src/main/scala/fs2/aws/s3.scala
@@ -221,7 +221,7 @@ object s3 {
           val chunkSizeBytes = partSize.value * 1000000
 
           // Range must be in the form "bytes=0-500" -> https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
-          def go(offset: Int): Pull[F, Byte, Unit] =
+          def go(offset: Long): Pull[F, Byte, Unit] =
             fs2.Stream
               .eval {
                 s3.getObject(


### PR DESCRIPTION
An integer overflow is eventually possible in `S3.readFileMultipart.go(int)` if you are downloading a large files over Integer.MAX_VALUE in size. ~2GB. I used A part-size of 25MB.

Eventually the offset will overflow, and you will send a negative range to the AWS API. You will also try to allocate a large chunk of memory, probably from the diff of the negative offset to the current range you are requesting. This will result in an OutOfMemoryError on the application.

I have reproduced this locally with minio, and you can see a negative range is passed down...
```
createbuckets_1  | 09:28:20.096 [206 Partial Content] s3.GetObject localhost:4566/data/output-largerer.csv 192.168.48.1      401.676ms    ↑ 130 B ↓ 24 MiB
createbuckets_1  | 09:28:21.093 [206 Partial Content] s3.GetObject localhost:4566/data/output-largerer.csv 192.168.48.1      367.404ms    ↑ 130 B ↓ 24 MiB
createbuckets_1  | 09:28:22.183 [206 Partial Content] s3.GetObject localhost:4566/data/output-largerer.csv 192.168.48.1      329.988ms    ↑ 130 B ↓ 24 MiB
createbuckets_1  | 09:28:23.038 [206 Partial Content] s3.GetObject localhost:4566/data/output-largerer.csv 192.168.48.1      264.542ms    ↑ 130 B ↓ 24 MiB
minio_1          |
minio_1          | API: GetObject(bucket=data, object=output-largerer.csv)
minio_1          | Time: 09:28:23 UTC 03/04/2021
minio_1          | DeploymentID: 35aa08ab-8da1-4794-8656-0f82020129f2
minio_1          | RequestID: 1669199D18D5F6B3
minio_1          | RemoteHost: 192.168.48.1
minio_1          | Host: localhost:4566
minio_1          | UserAgent: aws-sdk-java/2.15.82 Mac_OS_X/10.16 OpenJDK_64-Bit_Server_VM/11.0.10+9 Java/11.0.10 scala/2.13.5 vendor/AdoptOpenJDK io/async http/NettyNio
minio_1          | Error: Last byte position is negative ('-2144967211') (*errors.errorString)
minio_1          |        4: cmd/object-handlers.go:395:cmd.objectAPIHandlers.GetObjectHandler()
minio_1          |        3: cmd/http-tracer.go:204:cmd.Trace()
minio_1          |        2: cmd/handler-utils.go:378:cmd.httpTraceHdrs.func1()
minio_1          |        1: net/http/server.go:2069:http.HandlerFunc.ServeHTTP()
minio_1          |
minio_1          | API: GetObject(bucket=data, object=output-largerer.csv)
minio_1          | Time: 09:29:21 UTC 03/04/2021
minio_1          | DeploymentID: 35aa08ab-8da1-4794-8656-0f82020129f2
minio_1          | RequestID: 1669199D18D5F6B3
minio_1          | RemoteHost: 192.168.48.1
minio_1          | Host: localhost:4566
minio_1          | UserAgent: aws-sdk-java/2.15.82 Mac_OS_X/10.16 OpenJDK_64-Bit_Server_VM/11.0.10+9 Java/11.0.10 scala/2.13.5 vendor/AdoptOpenJDK io/async http/NettyNio
minio_1          | Error: Unable to write all the data to client write tcp 192.168.48.2:4566->192.168.48.1:64842: write: broken pipe (*fmt.wrapError)
minio_1          |        4: cmd/object-handlers.go:513:cmd.objectAPIHandlers.GetObjectHandler()
minio_1          |        3: cmd/http-tracer.go:204:cmd.Trace()
minio_1          |        2: cmd/handler-utils.go:378:cmd.httpTraceHdrs.func1()
minio_1          |        1: net/http/server.go:2069:http.HandlerFunc.ServeHTTP()
createbuckets_1  | 09:28:23.906 [200 OK] s3.GetObject localhost:4566/data/output-largerer.csv 192.168.48.1      57.319131s   ↑ 130 B ↓ 1.0 GiB
```

```
2021-03-04 09:28:22.170 [ioapp-compute-3] INFO  data.DataApp - Processed 25000001 records...
2021-03-04 09:28:23.032 [ioapp-compute-0] INFO  data.DataApp - Processed 25000001 records...
2021-03-04 09:28:23.901 [ioapp-compute-1] INFO  data.DataApp - Processed 25000001 records...
2021-03-04 09:29:20.250 [aws-java-sdk-NettyEventLoop-1-2] ERROR s.a.a.h.n.n.NettyNioAsyncHttpClient - Shutting down Netty EventLoopGroup did not complete within 16 seconds
software.amazon.awssdk.core.exception.SdkClientException: Unable to execute HTTP request: Java heap space
	at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:98)
	at software.amazon.awssdk.core.exception.SdkClientException.create(SdkClientException.java:43)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper.setLastException(RetryableStageHelper.java:198)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper.setLastException(RetryableStageHelper.java:194)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncRetryableStage$RetryingExecutor.maybeRetryExecute(AsyncRetryableStage.java:143)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncRetryableStage$RetryingExecutor.lambda$attemptExecute$1(AsyncRetryableStage.java:125)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
	at software.amazon.awssdk.utils.CompletableFutureUtils.lambda$forwardExceptionTo$0(CompletableFutureUtils.java:74)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.MakeAsyncHttpRequestStage.lambda$null$0(MakeAsyncHttpRequestStage.java:104)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.MakeAsyncHttpRequestStage$WrappedErrorForwardingResponseHandler.onError(MakeAsyncHttpRequestStage.java:158)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1.lambda$notifyError$5(ResponseHandler.java:309)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler.runAndLogError(ResponseHandler.java:181)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler.access$500(ResponseHandler.java:71)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1.notifyError(ResponseHandler.java:307)
	at software.amazon.awssdk.http.nio.netty.internal.utils.ExceptionHandlingUtils.tryCatch(ExceptionHandlingUtils.java:42)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1.onNext(ResponseHandler.java:270)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1.onNext(ResponseHandler.java:221)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher.publishMessage(HandlerPublisher.java:407)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher.channelRead(HandlerPublisher.java:383)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsHandler.handleReadHttpContent(HttpStreamsHandler.java:228)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsHandler.channelRead(HttpStreamsHandler.java:199)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsClientHandler.channelRead(HttpStreamsClientHandler.java:173)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at software.amazon.awssdk.http.nio.netty.internal.LastHttpContentHandler.channelRead(LastHttpContentHandler.java:43)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:271)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:311)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:432)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:834)
	at async @ io.laserdisc.pure.s3.tagless.Interpreter.eff1(Interpreter.scala:165)
	at map @ fs2.internal.CompileScope.interruptibleEval(CompileScope.scala:413)
	at flatMap @ fs2.internal.FreeC$.go$1(Algebra.scala:503)
	at flatMap @ fs2.internal.FreeC$.$anonfun$compile$7(Algebra.scala:463)
	at flatMap @ fs2.internal.FreeC$.go$1(Algebra.scala:460)
	at flatMap @ fs2.internal.FreeC$.$anonfun$compile$7(Algebra.scala:463)
	at flatMap @ fs2.internal.FreeC$.go$1(Algebra.scala:460)
	at flatMap @ fs2.internal.FreeC$.$anonfun$compile$7(Algebra.scala:463)
	at flatMap @ fs2.internal.FreeC$.go$1(Algebra.scala:460)
	at flatMap @ fs2.internal.FreeC$.$anonfun$compile$7(Algebra.scala:463)
	at flatMap @ fs2.internal.FreeC$.go$1(Algebra.scala:460)
	at flatMap @ fs2.internal.FreeC$.outerLoop$1(Algebra.scala:595)
	at flatMap @ fs2.internal.FreeC$.interruptGuard$1(Algebra.scala:436)
	at ifM$extension @ org.typelevel.log4cats.slf4j.internal.Slf4jLoggerInternal$Slf4jLogger.info(Slf4jLoggerInternal.scala:90)
	at as @ fs2.Stream$.$anonfun$evalTap$1(Stream.scala:1057)
	at map @ fs2.internal.CompileScope.interruptibleEval(CompileScope.scala:413)
Caused by: java.lang.OutOfMemoryError: Java heap space
	at java.base/java.util.Arrays.copyOf(Arrays.java:3745)
	at java.base/java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:120)
	at java.base/java.io.ByteArrayOutputStream.ensureCapacity(ByteArrayOutputStream.java:95)
	at java.base/java.io.ByteArrayOutputStream.write(ByteArrayOutputStream.java:156)
	at java.base/java.io.OutputStream.write(OutputStream.java:122)
	at software.amazon.awssdk.core.internal.async.ByteArrayAsyncResponseTransformer$BaosSubscriber.lambda$onNext$0(ByteArrayAsyncResponseTransformer.java:91)
	at software.amazon.awssdk.core.internal.async.ByteArrayAsyncResponseTransformer$BaosSubscriber$$Lambda$924/0x000000080074d840.run(Unknown Source)
	at software.amazon.awssdk.utils.FunctionalUtils.lambda$safeRunnable$5(FunctionalUtils.java:124)
	at software.amazon.awssdk.utils.FunctionalUtils$$Lambda$925/0x000000080074dc40.run(Unknown Source)
	at software.amazon.awssdk.utils.FunctionalUtils.invokeSafely(FunctionalUtils.java:140)
	at software.amazon.awssdk.core.internal.async.ByteArrayAsyncResponseTransformer$BaosSubscriber.onNext(ByteArrayAsyncResponseTransformer.java:91)
	at software.amazon.awssdk.core.internal.async.ByteArrayAsyncResponseTransformer$BaosSubscriber.onNext(ByteArrayAsyncResponseTransformer.java:68)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1.lambda$onNext$2(ResponseHandler.java:270)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1$$Lambda$922/0x000000080074d040.run(Unknown Source)
	at software.amazon.awssdk.http.nio.netty.internal.utils.ExceptionHandlingUtils.tryCatch(ExceptionHandlingUtils.java:40)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1.onNext(ResponseHandler.java:270)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1.onNext(ResponseHandler.java:221)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher.publishMessage(HandlerPublisher.java:407)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher.channelRead(HandlerPublisher.java:383)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsHandler.handleReadHttpContent(HttpStreamsHandler.java:228)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsHandler.channelRead(HttpStreamsHandler.java:199)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsClientHandler.channelRead(HttpStreamsClientHandler.java:173)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at software.amazon.awssdk.http.nio.netty.internal.LastHttpContentHandler.channelRead(LastHttpContentHandler.java:43)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)

Process finished with exit code 1
```

This PR changes the val holding the offset from an `Int` to a `Long`.