### PR TITLE
Reads s3 responses using an underlying stream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,11 +137,12 @@ lazy val `fs2-aws-s3` = (project in file("fs2-aws-s3"))
   .settings(
     name := "fs2-aws-s3",
     libraryDependencies ++= Seq(
-      "co.fs2"                 %% "fs2-core" % V.Fs2,
-      "co.fs2"                 %% "fs2-io"   % V.Fs2,
-      "eu.timepit"             %% "refined"  % V.Refined,
-      "software.amazon.awssdk" % "s3"        % V.AwsSdk,
-      "org.scalameta"          %% "munit"    % V.Munit % Test
+      "co.fs2"                 %% "fs2-core"             % V.Fs2,
+      "co.fs2"                 %% "fs2-io"               % V.Fs2,
+      "co.fs2"                 %% "fs2-reactive-streams" % V.Fs2,
+      "eu.timepit"             %% "refined"              % V.Refined,
+      "software.amazon.awssdk" % "s3"                    % V.AwsSdk,
+      "org.scalameta"          %% "munit"                % V.Munit % Test
     ),
     testFrameworks        += new TestFramework("munit.Framework"),
     coverageMinimum       := 0,

--- a/fs2-aws-s3/src/main/scala/fs2/aws/Fs2StreamAsyncResponseTransformer.scala
+++ b/fs2-aws-s3/src/main/scala/fs2/aws/Fs2StreamAsyncResponseTransformer.scala
@@ -1,0 +1,32 @@
+package fs2.aws
+
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
+
+import cats.effect.ConcurrentEffect
+import fs2.{ Chunk, Stream }
+import fs2.interop.reactivestreams.PublisherOps
+
+import software.amazon.awssdk.core.async.{ AsyncResponseTransformer, SdkPublisher }
+
+class Fs2StreamAsyncResponseTransformer[F[_]: ConcurrentEffect, ResponseT]
+    extends AsyncResponseTransformer[ResponseT, (ResponseT, Stream[F, Byte])] {
+
+  private val future              = new CompletableFuture[(ResponseT, Stream[F, Byte])]()
+  private var response: ResponseT = _
+
+  override def prepare(): CompletableFuture[(ResponseT, Stream[F, Byte])] = future
+
+  override def onResponse(response: ResponseT): Unit = this.response = response
+
+  override def onStream(publisher: SdkPublisher[ByteBuffer]): Unit = future.complete(
+    (response, publisher.toStream[F].flatMap(bb => Stream.chunk(Chunk.byteBuffer(bb))))
+  )
+
+  override def exceptionOccurred(error: Throwable): Unit = future.completeExceptionally(error)
+}
+
+object Fs2StreamAsyncResponseTransformer {
+  def apply[F[_]: ConcurrentEffect, ResponseT]: Fs2StreamAsyncResponseTransformer[F, ResponseT] =
+    new Fs2StreamAsyncResponseTransformer[F, ResponseT]
+}


### PR DESCRIPTION
Current implementation is using `AsyncResponseTransformer.toBytes` which loads the full s3 response in memory.
This replaces the `AsyncResponseTransformer` by one `Fs2StreamAsyncResponseTransformer` using the underlying reactivestreams `Publisher` to subscribe the returned `fs2.Stream`.
It should avoid loading the full s3 response in memory returning a `fs2.Stream` that returns chunks with the paginated s3 response.

I understand this is introducing a breaking change on `S3.create` method that now requires a `ConcurrentEffect` instead of just a `Concurrent`.

Not pretending to merge as-is. Just checking you opinions of this approach