### PR TITLE
Returns back ExecutionContext to Interpreter's caller

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,6 +119,7 @@ lazy val `fs2-aws-examples` = (project in file("fs2-aws-examples"))
     libraryDependencies ++= Seq(
       "org.mockito"    % "mockito-core"             % V.MockitoCore % Test,
       "org.mockito"    %% "mockito-scala-scalatest" % V.MockitoScalaTest % Test,
+      "com.amazonaws"  % "aws-java-sdk-sts"         % "1.12.5",
       "ch.qos.logback" % "logback-classic"          % "1.2.3",
       "ch.qos.logback" % "logback-core"             % "1.2.3",
       "org.slf4j"      % "jcl-over-slf4j"           % "1.7.30",

--- a/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/DynamoDB.scala
+++ b/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/DynamoDB.scala
@@ -1,0 +1,187 @@
+package fs2.aws.dynamodb
+
+import cats.effect.{ Blocker, Concurrent, ConcurrentEffect, ContextShift, Sync, Timer }
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.amazonaws.services.dynamodbv2.streamsadapter.{
+  AmazonDynamoDBStreamsAdapterClient,
+  StreamsWorkerFactory
+}
+import com.amazonaws.services.dynamodbv2.{ AmazonDynamoDB, AmazonDynamoDBStreams }
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{
+  InitialPositionInStream,
+  KinesisClientLibConfiguration,
+  Worker
+}
+import com.amazonaws.services.kinesis.model.Record
+import fs2.aws.core
+import fs2.concurrent.{ Queue, SignallingRef }
+import fs2.{ Pipe, Stream }
+
+trait DynamoDB[F[_]] {
+
+  /** Initialize a worker and start streaming records from a DynamoDB stream
+    * On stream finish (due to error or other), worker will be shutdown
+    *
+    * @tparam F effect type of the fs2 stream
+    * @param appName    name of the DynamoDB application. Used by KCL when resharding
+    * @param streamName name of the DynamoDB stream to consume from
+    * @return an infinite fs2 Stream that emits Kinesis Records
+    */
+  def readFromDynamoDBStream(appName: String, streamName: String): Stream[F, CommittableRecord]
+
+  /** Initialize a worker and start streaming records from a DynamoDB stream
+    * On stream finish (due to error or other), worker will be shutdown
+    *
+    * @tparam F effect type of the fs2 stream
+    * @param consumerConfig configuration parameters for the KCL
+    * @return an infinite fs2 Stream that emits DynamoDB Records
+    */
+  def readFromDynamoDBStream(
+    workerConfiguration: KinesisClientLibConfiguration
+  ): Stream[F, CommittableRecord]
+
+  /** Pipe to checkpoint records in Kinesis, marking them as processed
+    * Groups records by shard id, so that each shard is subject to its own clustering of records
+    * After accumulating maxBatchSize or reaching maxBatchWait for a respective shard, the latest record is checkpointed
+    * By design, all records prior to the checkpointed record are also checkpointed in Kinesis
+    *
+    * @tparam F effect type of the fs2 stream
+    * @param checkpointSettings configure maxBatchSize and maxBatchWait time before triggering a checkpoint
+    * @return a stream of Record types representing checkpointed messages
+    */
+  def checkpointRecords(
+    checkpointSettings: KinesisCheckpointSettings
+  ): Pipe[F, CommittableRecord, Record]
+
+}
+
+object DynamoDB {
+
+  abstract class GenericKinesis[F[_]: ConcurrentEffect: ContextShift: Timer] extends DynamoDB[F] {
+
+    private[dynamodb] def readChunksFromDynamoDBStream(
+      blocker: Blocker,
+      schedulerFactory: IRecordProcessorFactory => F[Worker]
+    ): Stream[F, CommittableRecord] = {
+      // Initialize a KCL scheduler which appends to the internal stream queue on message receipt
+      def instantiateScheduler(
+        queue: Queue[F, CommittableRecord],
+        signal: SignallingRef[F, Boolean]
+      ): fs2.Stream[F, Worker] =
+        Stream.bracket {
+          schedulerFactory(() =>
+            new RecordProcessor(records =>
+              ConcurrentEffect[F].toIO(queue.enqueue1(records)).unsafeRunSync()
+            )
+          ).flatTap(s => Concurrent[F].start(blocker.delay(s.run()).flatTap(_ => signal.set(true))))
+        }(s => blocker.delay(s.shutdown()))
+
+      // Instantiate a new bounded queue and concurrently run the queue populator
+      // Expose the elements by dequeuing the internal buffer
+      for {
+        buffer          <- Stream.eval(Queue.unbounded[F, CommittableRecord])
+        interruptSignal <- Stream.eval(SignallingRef[F, Boolean](false))
+        _               <- instantiateScheduler(buffer, interruptSignal)
+        stream          <- buffer.dequeue.interruptWhen(interruptSignal)
+      } yield stream
+    }
+    def checkpointRecords(
+      checkpointSettings: KinesisCheckpointSettings // = KinesisCheckpointSettings.defaultInstance
+    ): Pipe[F, CommittableRecord, Record] = {
+      def checkpoint(
+        checkpointSettings: KinesisCheckpointSettings
+      ): Pipe[F, CommittableRecord, Record] =
+        _.groupWithin(checkpointSettings.maxBatchSize, checkpointSettings.maxBatchWait)
+          .collect { case chunk if chunk.size > 0 => chunk.size -> chunk.toList.max }
+          .flatMap { case (len, cr) => fs2.Stream.eval_(cr.checkpoint[F](len).as(cr.record)) }
+
+      def bypass: Pipe[F, CommittableRecord, Record] = _.map(r => r.record)
+
+      _.through(core.groupBy(r => Sync[F].pure(r.shardId))).map {
+        case (_, st) =>
+          st.broadcastThrough(checkpoint(checkpointSettings), bypass)
+      }.parJoinUnbounded
+    }
+  }
+  def create[F[_]: ConcurrentEffect: ContextShift: Timer](
+    blocker: Blocker,
+    schedulerFactory: IRecordProcessorFactory => F[Worker]
+  ): DynamoDB[F] = new GenericKinesis[F] {
+
+    override def readFromDynamoDBStream(
+      appName: String,
+      streamName: String
+    ): Stream[F, CommittableRecord] = readChunksFromDynamoDBStream(blocker, schedulerFactory)
+
+    override def readFromDynamoDBStream(
+      workerConfiguration: KinesisClientLibConfiguration
+    ): Stream[F, CommittableRecord] = readChunksFromDynamoDBStream(blocker, schedulerFactory)
+  }
+
+  def create[F[_]: ConcurrentEffect: ContextShift: Timer](
+    dynamoDBStreamsClient: AmazonDynamoDBStreams,
+    dynamoDBClient: AmazonDynamoDB,
+    cloudWatchClient: AmazonCloudWatch,
+    blocker: Blocker
+  ): DynamoDB[F] = {
+
+    def defaultScheduler(
+      workerConfiguration: KinesisClientLibConfiguration,
+      dynamoDBStreamsClient: AmazonDynamoDBStreams,
+      dynamoDBClient: AmazonDynamoDB,
+      cloudWatchClient: AmazonCloudWatch
+    ): IRecordProcessorFactory => F[Worker] = { recordProcessorFactory: IRecordProcessorFactory =>
+      val adapterClient = new AmazonDynamoDBStreamsAdapterClient(dynamoDBStreamsClient)
+      StreamsWorkerFactory
+        .createDynamoDbStreamsWorker(
+          recordProcessorFactory,
+          workerConfiguration,
+          adapterClient,
+          dynamoDBClient,
+          cloudWatchClient
+        )
+        .pure[F]
+    }
+
+    new GenericKinesis[F] {
+      override def readFromDynamoDBStream(
+        appName: String,
+        streamName: String
+      ): Stream[F, CommittableRecord] =
+        for {
+          provider <- Stream.eval(Sync[F].delay(DefaultAWSCredentialsProviderChain.getInstance()))
+          workerId <- Stream.eval(Sync[F].delay(java.util.UUID.randomUUID().toString))
+          conf <- Stream.eval(
+                   Sync[F].delay(
+                     new KinesisClientLibConfiguration(
+                       appName,
+                       streamName,
+                       provider,
+                       workerId
+                     ).withInitialPositionInStream(InitialPositionInStream.TRIM_HORIZON)
+                   )
+                 )
+          res <- readFromDynamoDBStream(conf)
+
+        } yield res
+
+      override def readFromDynamoDBStream(
+        workerConfiguration: KinesisClientLibConfiguration
+      ): Stream[F, CommittableRecord] =
+        readChunksFromDynamoDBStream(
+          blocker,
+          defaultScheduler(
+            workerConfiguration,
+            dynamoDBStreamsClient,
+            dynamoDBClient,
+            cloudWatchClient
+          )
+        )
+    }
+  }
+}

--- a/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/package.scala
+++ b/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/package.scala
@@ -53,6 +53,7 @@ package object dynamodb {
     *  @param streamName name of the Kinesis stream to consume from
     *  @return an infinite fs2 Stream that emits Kinesis Records
     */
+  @deprecated("Use fs2.aws.dynamodb.DynamoDB instead", since = "3.2.0")
   def readFromDynamDBStream[F[_]: ConcurrentEffect: ContextShift](
     appName: String,
     streamName: String
@@ -77,6 +78,7 @@ package object dynamodb {
     *  @param streamConfig configuration for the internal stream
     *  @return an infinite fs2 Stream that emits Kinesis Records
     */
+  @deprecated("Use fs2.aws.dynamodb.DynamoDB instead", since = "3.2.0")
   def readFromDynamoDBStream[F[_]: ConcurrentEffect: ContextShift](
     workerConfiguration: KinesisClientLibConfiguration,
     dynamoDBStreamsClient: AmazonDynamoDBStreams =
@@ -140,6 +142,8 @@ package object dynamodb {
     *  @param checkpointSettings configure maxBatchSize and maxBatchWait time before triggering a checkpoint
     *  @return a stream of Record types representing checkpointed messages
     */
+
+  @deprecated("Use fs2.aws.dynamodb.DynamoDB instead", since = "3.2.0")
   def checkpointRecords[F[_]: ConcurrentEffect: Timer](
     checkpointSettings: KinesisCheckpointSettings = KinesisCheckpointSettings.defaultInstance,
     parallelism: Int = 10
@@ -168,6 +172,8 @@ package object dynamodb {
     *  @param checkpointSettings configure maxBatchSize and maxBatchWait time before triggering a checkpoint
     *  @return a Sink that accepts a stream of CommittableRecords
     */
+
+  @deprecated("Use fs2.aws.dynamodb.DynamoDB instead", since = "3.2.0")
   def checkpointRecords_[F[_]](
     checkpointSettings: KinesisCheckpointSettings = KinesisCheckpointSettings.defaultInstance
   )(implicit F: ConcurrentEffect[F], timer: Timer[F]): Pipe[F, CommittableRecord, Unit] =

--- a/fs2-aws-dynamodb/src/test/scala/fs2/aws/dynamodb/NewDynamoDBConsumerSpec.scala
+++ b/fs2-aws-dynamodb/src/test/scala/fs2/aws/dynamodb/NewDynamoDBConsumerSpec.scala
@@ -1,9 +1,6 @@
-package fs2
-package aws
+package fs2.aws.dynamodb
 
-import java.util.Date
-import java.util.concurrent.{ Phaser, Semaphore }
-import cats.effect.{ ContextShift, IO, Timer }
+import cats.effect.{ Blocker, ContextShift, IO, Timer }
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model
 import com.amazonaws.services.dynamodbv2.model.{ AttributeValue, StreamRecord }
@@ -14,27 +11,28 @@ import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{
   IRecordProcessorFactory
 }
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{ ShutdownReason, Worker }
-import com.amazonaws.services.kinesis.clientlibrary.types._
+import com.amazonaws.services.kinesis.clientlibrary.types.{
+  ExtendedSequenceNumber,
+  InitializationInput,
+  ProcessRecordsInput,
+  ShutdownInput
+}
 import com.amazonaws.services.kinesis.model.Record
-import fs2.aws.dynamodb._
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
-import org.mockito.invocation.InvocationOnMock
-import org.scalatest.{ BeforeAndAfterEach, Ignore }
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time._
 
-import scala.annotation.nowarn
-import scala.collection.immutable
+import java.util.Date
+import java.util.concurrent.{ CountDownLatch, Executors, Phaser, Semaphore }
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
-@Ignore
-@nowarn
-class DynamoDBConsumerSpec
+class NewDynamoDBConsumerSpec
     extends AnyFlatSpec
     with Matchers
     with BeforeAndAfterEach
@@ -44,12 +42,13 @@ class DynamoDBConsumerSpec
   implicit val timer: Timer[IO]                 = IO.timer(ec)
   implicit val ioContextShift: ContextShift[IO] = IO.contextShift(ec)
 
+  implicit def sList2jList[A](sList: List[A]): java.util.List[A] = sList.asJava
+
   implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(2, Seconds)), interval = scaled(Span(5, Millis)))
 
-  "KinesisWorker source" should "successfully read data from the Kinesis stream" in new WorkerContext
+  "DynamoDB source" should "successfully read data from the DynamoDB stream" in new WorkerContext
     with TestData {
-
     val res = (
       stream.take(1).compile.toList,
       IO.delay {
@@ -59,9 +58,7 @@ class DynamoDBConsumerSpec
       }
     ).parMapN { case (msgs, _) => msgs }.unsafeRunSync()
 
-    verify(mockWorker, times(1)).run()
-
-    val commitableRecord = res.head
+    val commitableRecord: CommittableRecord = res.head
     commitableRecord.record.getData                        should be(record.getData)
     commitableRecord.recordProcessorStartingSequenceNumber shouldBe initializationInput.getExtendedSequenceNumber
     commitableRecord.shardId                               shouldBe initializationInput.getShardId
@@ -79,10 +76,10 @@ class DynamoDBConsumerSpec
       }
     ).parMapN { case (_, _) => () }.unsafeRunSync()
 
-    verify(mockWorker, times(1)).shutdown()
+    verify(mockScheduler, times(1)).shutdown()
   }
 
-  it should "shutdown the worker if the stream terminates" in new WorkerContext(errorStream = true)
+  it should "Shutdown the worker if the stream terminates" in new WorkerContext(errorStream = true)
     with TestData {
     intercept[Exception] {
       (
@@ -94,41 +91,36 @@ class DynamoDBConsumerSpec
         }
       ).parMapN { case (_, _) => () }.unsafeRunSync()
     }
-    verify(mockWorker, times(1)).shutdown()
+
+    verify(mockScheduler, times(1)).shutdown()
   }
 
   it should "not drop messages in case of back-pressure" in new WorkerContext with TestData {
     // Create and send 10 records (to match buffer size)
-    val res = (
-      stream.take(10).compile.toList,
-      IO.delay {
-        semaphore.acquire()
-        recordProcessor.initialize(initializationInput)
-        for (i <- 1 to 10) {
-          val record: Record = mock(classOf[RecordAdapter])
-          when(record.getSequenceNumber).thenReturn(i.toString)
-          recordProcessor.processRecords(recordsInput.withRecords(List(record).asJava))
+    val res =
+      (stream.take(60).compile.toList, Blocker[IO].use { b =>
+        b.blockOn {
+          (IO.delay {
+            semaphore.acquire()
+            recordProcessor.initialize(initializationInput)
+            for (i <- 1 to 10) {
+              val record: Record = mock(classOf[RecordAdapter])
+              when(record.getSequenceNumber).thenReturn(i.toString)
+              recordProcessor.processRecords(recordsInput.withRecords(List(record).asJava))
+            }
+          }, IO.delay {
+            semaphore.acquire()
+            recordProcessor.initialize(initializationInput)
+            for (i <- 1 to 50) {
+              val record: Record = mock(classOf[RecordAdapter])
+              when(record.getSequenceNumber).thenReturn(i.toString)
+              recordProcessor.processRecords(recordsInput.withRecords(List(record).asJava))
+            }
+          }).parMapN { case (_, _) => () }
         }
-      }
-    ).parMapN { case (msgs, _) => msgs }.unsafeRunSync()
+      }).parMapN { case (msgs, _) => msgs }.unsafeRunSync()
 
-    res should have size 10
-
-    // Send a batch that exceeds the internal buffer size
-    val res2 = (
-      stream.take(50).compile.toList,
-      IO.delay {
-        semaphore.acquire()
-        recordProcessor.initialize(initializationInput)
-        for (i <- 1 to 50) {
-          val record: Record = mock(classOf[RecordAdapter])
-          when(record.getSequenceNumber).thenReturn(i.toString)
-          recordProcessor.processRecords(recordsInput.withRecords(List(record).asJava))
-        }
-      }
-    ).parMapN { case (msgs, _) => msgs }.unsafeRunSync()
-
-    res2 should have size 50
+    res should have size 60
   }
 
   it should "not drop messages in case of back-pressure with multiple shard workers" in new WorkerContext
@@ -147,8 +139,11 @@ class DynamoDBConsumerSpec
       },
       IO.delay {
         semaphore.acquire()
-        recordProcessor2.initialize(initializationInput.withShardId("shard2"))
-
+        recordProcessor2.initialize(
+          new InitializationInput()
+            .withShardId("shard2")
+            .withExtendedSequenceNumber(ExtendedSequenceNumber.AT_TIMESTAMP)
+        )
         // Create and send 10 records (to match buffer size)
         for (i <- 1 to 5) {
           val record: Record = mock(classOf[RecordAdapter])
@@ -165,47 +160,50 @@ class DynamoDBConsumerSpec
   it should "delay the end of shard checkpoint until all messages are drained" in new WorkerContext
     with TestData {
     val nRecords = 5
-    val res = (
+    val res: Seq[Record] = (
       stream
         .take(nRecords)
         //emulate message processing latency to reproduce the situation when End of Shard arrives BEFORE
         // all in-flight records are done
         .parEvalMap(3)(msg => IO.sleep(200 millis) >> IO.pure(msg))
         .through(
-          checkpointRecords[IO](
+          k.checkpointRecords(
             KinesisCheckpointSettings(maxBatchSize = Int.MaxValue, maxBatchWait = 500.millis)
               .getOrElse(throw new Error())
           )
         )
         .compile
         .toList,
-      IO.delay {
-        semaphore.acquire()
-        recordProcessor.initialize(initializationInput)
-        (1 to nRecords).foreach { i =>
-          val record: Record = mock(classOf[RecordAdapter])
-          when(record.getSequenceNumber).thenReturn(i.toString)
-          val ri = new ProcessRecordsInput()
-            .withCheckpointer(checkpointer)
-            .withMillisBehindLatest(1L)
-            .withRecords(List(record).asJava)
-          recordProcessor.processRecords(ri)
-        }
-        //Immediately publish end of shard event
-        recordProcessor.shutdown(
-          new ShutdownInput()
-            .withCheckpointer(checkpointer)
-            .withShutdownReason(ShutdownReason.TERMINATE)
-        )
+      Blocker[IO].use { blocker =>
+        blocker.blockOn(IO.delay {
+          semaphore.acquire()
+          recordProcessor.initialize(initializationInput)
+          (1 to nRecords).foreach { i =>
+            val record: Record = mock(classOf[RecordAdapter])
+            when(record.getSequenceNumber).thenReturn(i.toString)
+            val ri = new ProcessRecordsInput()
+              .withCheckpointer(checkpointer)
+              .withMillisBehindLatest(1L)
+              .withRecords(List(record).asJava)
+            recordProcessor.processRecords(ri)
+          }
+        } >> IO.delay {
+          //Immediately publish end of shard event
+          recordProcessor.shutdown(
+            new ShutdownInput()
+              .withCheckpointer(checkpointer)
+              .withShutdownReason(ShutdownReason.TERMINATE)
+          )
+        })
       }
     ).parMapN { case (msgs, _) => msgs }.unsafeRunSync()
 
     res should have size 5
   }
 
-  "KinesisWorker checkpoint pipe" should "checkpoint batch of records with same sequence number" in new KinesisWorkerCheckpointContext {
+  "KinesisWorker checkpoint pipe" should "checkpoint batch of records with same sequence number" in new WorkerContext() {
     val inFlightRecordsPhaser = new Phaser(1)
-    val input: immutable.IndexedSeq[CommittableRecord] = (1 to 3) map { i =>
+    val input = (1 to 3) map { i =>
       val record = mock(classOf[RecordAdapter])
       when(record.getSequenceNumber).thenReturn(i.toString)
       new CommittableRecord(
@@ -213,7 +211,7 @@ class DynamoDBConsumerSpec
         mock(classOf[ExtendedSequenceNumber]),
         1L,
         record,
-        recordProcessor,
+        new RecordProcessor(_ => ()),
         checkpointerShard1,
         inFlightRecordsPhaser
       )
@@ -226,12 +224,11 @@ class DynamoDBConsumerSpec
     }
   }
 
-  it should "checkpoint batch of records of different shards" in new KinesisWorkerCheckpointContext {
-    val checkpointerShard2: IRecordProcessorCheckpointer =
-      mock(classOf[IRecordProcessorCheckpointer])
-
+  it should "checkpoint batch of records of different shards" in new WorkerContext() {
+    val checkpointerShard2    = mock(classOf[IRecordProcessorCheckpointer])
     val inFlightRecordsPhaser = new Phaser(1)
-    val input: immutable.IndexedSeq[CommittableRecord] = (1 to 6) map { i =>
+
+    val input = (1 to 6) map { i =>
       if (i <= 3) {
         val record = mock(classOf[RecordAdapter])
         when(record.getSequenceNumber).thenReturn(i.toString)
@@ -240,7 +237,7 @@ class DynamoDBConsumerSpec
           mock(classOf[ExtendedSequenceNumber]),
           i,
           record,
-          recordProcessor,
+          new RecordProcessor(_ => ()),
           checkpointerShard1,
           inFlightRecordsPhaser
         )
@@ -252,7 +249,7 @@ class DynamoDBConsumerSpec
           mock(classOf[ExtendedSequenceNumber]),
           i,
           record,
-          recordProcessor,
+          new RecordProcessor(_ => ()),
           checkpointerShard2,
           inFlightRecordsPhaser
         )
@@ -268,14 +265,20 @@ class DynamoDBConsumerSpec
 
   }
 
-  it should "not checkpoint the batch if the IRecordProcessor has been shutdown with ZOMBIE reason" in new KinesisWorkerCheckpointContext {
-    recordProcessor.shutdown(
+  it should "not checkpoint the batch if the IRecordProcessor has been shutdown with ZOMBIE reason" in new WorkerContext() {
+
+    val cS: IRecordProcessorCheckpointer = mock(
+      classOf[IRecordProcessorCheckpointer]
+    )
+
+    val rp = new RecordProcessor(_ => ())
+    rp.shutdown(
       new ShutdownInput()
         .withShutdownReason(ShutdownReason.ZOMBIE)
         .withCheckpointer(checkpointerShard1)
     )
 
-    val input: immutable.IndexedSeq[CommittableRecord] = (1 to 3) map { i =>
+    val input = (1 to 3) map { i =>
       val record = mock(classOf[RecordAdapter])
       when(record.getSequenceNumber).thenReturn("1")
       new CommittableRecord(
@@ -283,21 +286,22 @@ class DynamoDBConsumerSpec
         mock(classOf[ExtendedSequenceNumber]),
         1L,
         record,
-        recordProcessor,
-        checkpointerShard1,
-        recordProcessor.inFlightRecordsPhaser
+        rp,
+        cS,
+        rp.inFlightRecordsPhaser
       )
     }
 
     startStream(input)
 
-    verify(checkpointerShard1, times(0)).checkpoint()
+    verify(checkpointerShard1, never()).checkpoint()
   }
 
-  it should "fail with Exception if checkpoint action fails" in new KinesisWorkerCheckpointContext {
-    val checkpointer: IRecordProcessorCheckpointer = mock(classOf[IRecordProcessorCheckpointer])
-    val inFlightRecordsPhaser                      = new Phaser(1)
-    val record: RecordAdapter                      = mock(classOf[RecordAdapter])
+  it should "fail with Exception if checkpoint action fails" in new WorkerContext() {
+    val checkpointer          = mock(classOf[IRecordProcessorCheckpointer])
+    val inFlightRecordsPhaser = new Phaser(1)
+    val record                = mock(classOf[RecordAdapter])
+    val rp                    = new RecordProcessor(_ => ())
     when(record.getSequenceNumber).thenReturn("1")
 
     val input = new CommittableRecord(
@@ -305,7 +309,7 @@ class DynamoDBConsumerSpec
       mock(classOf[ExtendedSequenceNumber]),
       1L,
       record,
-      recordProcessor,
+      rp,
       checkpointer,
       inFlightRecordsPhaser
     )
@@ -315,7 +319,7 @@ class DynamoDBConsumerSpec
 
     the[RuntimeException] thrownBy fs2.Stream
       .emits(Seq(input))
-      .through(checkpointRecords[IO](settings))
+      .through(k.checkpointRecords(settings))
       .compile
       .toVector
       .unsafeRunSync() should have message "you have no power here"
@@ -323,38 +327,80 @@ class DynamoDBConsumerSpec
     eventually(verify(checkpointer).checkpoint(input.record))
   }
 
+  it should "bypass all items when checkpoint" in new WorkerContext() {
+    val checkpointer          = mock(classOf[IRecordProcessorCheckpointer])
+    val inFlightRecordsPhaser = new Phaser(1)
+    val rp                    = new RecordProcessor(_ => ())
+
+    val record = mock(classOf[RecordAdapter])
+    when(record.getSequenceNumber).thenReturn("1")
+
+    val input = (1 to 100).map(idx =>
+      new CommittableRecord(
+        s"shard-1",
+        mock(classOf[ExtendedSequenceNumber]),
+        idx,
+        record,
+        rp,
+        checkpointer,
+        inFlightRecordsPhaser
+      )
+    )
+
+    fs2.Stream
+      .emits(input)
+      .through(k.checkpointRecords(settings))
+      .compile
+      .toVector
+      .unsafeRunSync() should have size 100
+  }
+
   abstract private class WorkerContext(errorStream: Boolean = false) {
 
-    val semaphore = new Semaphore(1)
-    semaphore.acquire()
-    var output = List.newBuilder[CommittableRecord]
-
-    protected val mockWorker: Worker = mock(classOf[Worker])
-
-    when(mockWorker.run()).thenAnswer((invocation: InvocationOnMock) => ())
-
-    when(mockWorker.shutdown()).thenAnswer((invocation: InvocationOnMock) => ())
+    val semaphore                       = new Semaphore(0)
+    val latch                           = new CountDownLatch(1)
+    protected val mockScheduler: Worker = mock(classOf[Worker])
 
     var recordProcessorFactory: IRecordProcessorFactory = _
     var recordProcessor: IRecordProcessor               = _
     var recordProcessor2: IRecordProcessor              = _
+//    val chunkedRecordProcessor                          = new ChunkedRecordProcessor(_ => ())
 
-    val builder: IRecordProcessorFactory => Worker = { x: IRecordProcessorFactory =>
+    doAnswer(_ => latch.await()).when(mockScheduler).run()
+
+    val builder = { x: IRecordProcessorFactory =>
       recordProcessorFactory = x
       recordProcessor = x.createProcessor()
       semaphore.release()
       recordProcessor2 = x.createProcessor()
       semaphore.release()
-      mockWorker
+      mockScheduler.pure[IO]
     }
 
-    val config: KinesisStreamSettings =
-      KinesisStreamSettings(bufferSize = 10, 10.seconds)
-        .getOrElse(throw new RuntimeException("cannot create Kinesis Settings"))
-
-    val stream: Stream[IO, CommittableRecord] =
-      readFromDynamoDBStream[IO](builder, config)
+    val k =
+      DynamoDB.create[IO](
+        Blocker.liftExecutionContext(
+          ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
+        ),
+        builder
+      )
+    val stream: fs2.Stream[IO, CommittableRecord] =
+      k.readFromDynamoDBStream("testStream", "testApp")
         .map(i => if (errorStream) throw new Exception("boom") else i)
+        .onFinalize(IO.delay(latch.countDown()))
+    val settings =
+      KinesisCheckpointSettings(maxBatchSize = Int.MaxValue, maxBatchWait = 500.millis)
+        .getOrElse(throw new Error())
+
+    val checkpointerShard1 = mock(classOf[IRecordProcessorCheckpointer])
+
+    def startStream(input: Seq[CommittableRecord]): Seq[Record] =
+      fs2.Stream
+        .emits(input)
+        .through(k.checkpointRecords(settings))
+        .compile
+        .toList
+        .unsafeRunSync()
   }
 
   private trait TestData {
@@ -372,7 +418,7 @@ class DynamoDBConsumerSpec
     doAnswer { _ =>
       if (endOfShardSeen) throw new Exception("Checkpointing after End Of Shard")
       null
-    }.when(checkpointer).checkpoint(any[Record])
+    }.when(checkpointer).checkpoint(any[String], any[Long])
 
     val initializationInput: InitializationInput = {
       new InitializationInput()
@@ -392,23 +438,7 @@ class DynamoDBConsumerSpec
         .withCheckpointer(checkpointer)
         .withMillisBehindLatest(1L)
         .withRecords(List(record).asJava)
+
   }
 
-  private trait KinesisWorkerCheckpointContext {
-    val recordProcessor = new RecordProcessor(_ => ())
-    val checkpointerShard1: IRecordProcessorCheckpointer = mock(
-      classOf[IRecordProcessorCheckpointer]
-    )
-    val settings: KinesisCheckpointSettings =
-      KinesisCheckpointSettings(maxBatchSize = 100, maxBatchWait = 500.millis)
-        .getOrElse(throw new RuntimeException("Cannot create Kinesis Checkpoint Settings"))
-
-    def startStream(input: Seq[CommittableRecord]): Unit =
-      fs2.Stream
-        .emits(input)
-        .through(checkpointRecords[IO](settings))
-        .compile
-        .toVector
-        .unsafeRunAsync(_ => ())
-  }
 }

--- a/fs2-aws-examples/src/main/scala/DynamoDBStreamer.scala
+++ b/fs2-aws-examples/src/main/scala/DynamoDBStreamer.scala
@@ -1,23 +1,65 @@
-import cats.effect.{ ExitCode, IO, IOApp }
-import fs2.aws.dynamodb
-import fs2.aws.dynamodb.parsers
-import org.typelevel.log4cats.SelfAwareStructuredLogger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
+import cats.effect.{ Blocker, ExitCode, IO, IOApp, Resource }
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.cloudwatch.{ AmazonCloudWatch, AmazonCloudWatchClientBuilder }
+import com.amazonaws.services.dynamodbv2.{
+  AmazonDynamoDB,
+  AmazonDynamoDBClientBuilder,
+  AmazonDynamoDBStreams,
+  AmazonDynamoDBStreamsClientBuilder
+}
+import fs2.aws.dynamodb.{ parsers, DynamoDB }
 import io.circe.Json
 import io.github.howardjohn.scanamo.CirceDynamoFormat._
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object DynamoDBStreamer extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
+    resources.use {
+      case (blocker, streams, ddb, watch) =>
+        for {
+          logger <- Slf4jLogger.fromName[IO]("example")
+
+          ddbStream = DynamoDB.create[IO](streams, ddb, watch, blocker)
+          _ <- ddbStream
+                .readFromDynamoDBStream(
+                  "app-name",
+                  "ddb-stream-arn"
+                )
+                .evalMap(cr => parsers.parseDynamoEvent[IO, Json](cr.record))
+                .evalTap(msg => logger.info(s"received $msg"))
+                .compile
+                .drain
+        } yield ExitCode.Success
+    }
+
+  def resources: Resource[IO, (Blocker, AmazonDynamoDBStreams, AmazonDynamoDB, AmazonCloudWatch)] =
     for {
-      implicit0(logger: SelfAwareStructuredLogger[IO]) <- Slf4jLogger.fromName[IO]("example")
-      _ <- dynamodb
-            .readFromDynamDBStream[IO](
-              "dynamo_db_example",
-              "arn:aws:dynamodb:us-east-1:023006903388:table/nightly-sync-events-Production/stream/2020-01-27T22:49:13.204"
-            )
-            .evalMap(cr => parsers.parseDynamoEvent[IO, Json](cr.record))
-            .evalTap(msg => logger.info(s"received $msg"))
-            .compile
-            .drain
-    } yield ExitCode.Success
+      b <- Blocker[IO]
+      dynamoDBStreamsClient <- Resource.make(
+                                IO.delay(
+                                  AmazonDynamoDBStreamsClientBuilder
+                                    .standard()
+                                    .withRegion(Regions.US_EAST_1)
+                                    .build()
+                                )
+                              )(res => IO.delay(res.shutdown()))
+
+      dynamoDBClient <- Resource.make(
+                         IO.delay(
+                           AmazonDynamoDBClientBuilder
+                             .standard()
+                             .withRegion(Regions.US_EAST_1)
+                             .build()
+                         )
+                       )(res => IO.delay(res.shutdown()))
+      cloudWatchClient <- Resource.make(
+                           IO.delay(
+                             AmazonCloudWatchClientBuilder
+                               .standard()
+                               .withRegion(Regions.US_EAST_1)
+                               .build()
+                           )
+                         )(res => IO.delay(res.shutdown()))
+
+    } yield (b, dynamoDBStreamsClient, dynamoDBClient, cloudWatchClient)
 }

--- a/fs2-aws-examples/src/main/scala/DynamoParallelScan.scala
+++ b/fs2-aws-examples/src/main/scala/DynamoParallelScan.scala
@@ -1,5 +1,5 @@
 import cats.data.Kleisli
-import cats.effect.{ Blocker, ExitCode, IO, IOApp, Sync }
+import cats.effect.{ ExitCode, IO, IOApp, Sync }
 import cats.implicits._
 import fs2.{ Chunk, Pipe }
 import fs2.aws.dynamodb.StreamScan
@@ -81,8 +81,7 @@ case class DDBEnvironment[F[_]](
 object DynamoParallelScan extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
     (for {
-      b <- Blocker[IO]
-      ddb <- Interpreter[IO](b)
+      ddb <- Interpreter[IO]
               .DynamoDbAsyncClientOpResource(
                 DynamoDbAsyncClient
                   .builder()

--- a/fs2-aws-examples/src/main/scala/KinesisExample.scala
+++ b/fs2-aws-examples/src/main/scala/KinesisExample.scala
@@ -52,10 +52,10 @@ object KinesisExample extends IOApp {
   ) =
     for {
       b                  <- Blocker[F]
-      i                  = KinesisInterpreter[F](b)
+      i                  = KinesisInterpreter[F]
       k                  <- i.KinesisAsyncClientResource(kac)
-      d                  <- DynamoDbInterpreter[F](b).DynamoDbAsyncClientResource(dac)
-      c                  <- CloudwatchInterpreter[F](b).CloudWatchAsyncClientResource(cac)
+      d                  <- DynamoDbInterpreter[F].DynamoDbAsyncClientResource(dac)
+      c                  <- CloudwatchInterpreter[F].CloudWatchAsyncClientResource(cac)
       kinesisInterpreter = i.create(k)
       _                  <- disposableStream(kinesisInterpreter, streamName)
     } yield Kinesis.create[F](k, d, c, b)

--- a/fs2-aws-examples/src/main/scala/S3Example.scala
+++ b/fs2-aws-examples/src/main/scala/S3Example.scala
@@ -19,7 +19,7 @@ object S3Example extends IOApp {
       blocker     <- Blocker[IO]
       credentials = AwsBasicCredentials.create("accesskey", "secretkey")
       port        = 4566
-      s3 <- S3Interpreter[IO](blocker).S3AsyncClientOpResource(
+      s3 <- S3Interpreter[IO].S3AsyncClientOpResource(
              S3AsyncClient
                .builder()
                .credentialsProvider(StaticCredentialsProvider.create(credentials))

--- a/fs2-aws-s3/src/test/scala/fs2/aws/s3/S3Suite.scala
+++ b/fs2-aws-s3/src/test/scala/fs2/aws/s3/S3Suite.scala
@@ -19,7 +19,7 @@ class S3Suite extends IOSuite {
       .create("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
 
   val s3R: Resource[IO, S3AsyncClientOp[IO]] =
-    Interpreter[IO](blocker).S3AsyncClientOpResource(
+    Interpreter[IO].S3AsyncClientOpResource(
       S3AsyncClient
         .builder()
         .credentialsProvider(StaticCredentialsProvider.create(credentials))

--- a/fs2-aws-sns/src/test/scala/fs2/aws/sns/SnsSpec.scala
+++ b/fs2-aws-sns/src/test/scala/fs2/aws/sns/SnsSpec.scala
@@ -1,6 +1,6 @@
 package fs2.aws.sns
 
-import cats.effect.{ Blocker, ContextShift, IO, Resource, Timer }
+import cats.effect.{ ContextShift, IO, Resource, Timer }
 import fs2.aws.sns.sns.SNS
 import io.laserdisc.pure.sns.tagless.{ Interpreter, SnsAsyncClientOp }
 import io.laserdisc.pure.sqs.tagless
@@ -32,7 +32,6 @@ class SnsSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   var topicArn: String = _
   var queueUrl: String = _
   val pattern: Regex   = new Regex("\"Message\": \"[0-9]\"")
-  val blocker          = Blocker.liftExecutionContext(ec)
 
   override def beforeAll(): Unit =
     awsClientsResource
@@ -126,7 +125,7 @@ class SnsSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   def mkSNSClient(snsPort: Int): Resource[IO, SnsAsyncClientOp[IO]] = {
     val credentials =
       AwsBasicCredentials.create("accesskey", "secretkey")
-    Interpreter[IO](blocker).SnsAsyncClientOpResource(
+    Interpreter[IO].SnsAsyncClientOpResource(
       SnsAsyncClient
         .builder()
         .credentialsProvider(StaticCredentialsProvider.create(credentials))
@@ -139,7 +138,7 @@ class SnsSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     val credentials =
       AwsBasicCredentials.create("accesskey", "secretkey")
     tagless
-      .Interpreter[IO](blocker)
+      .Interpreter[IO]
       .SqsAsyncClientOpResource(
         SqsAsyncClient
           .builder()

--- a/fs2-aws-sqs/src/test/scala/fs2/aws/sqs/SqsSpec.scala
+++ b/fs2-aws-sqs/src/test/scala/fs2/aws/sqs/SqsSpec.scala
@@ -1,6 +1,6 @@
 package sqs
 
-import cats.effect.{ Blocker, ContextShift, IO, Resource, Timer }
+import cats.effect.{ ContextShift, IO, Resource, Timer }
 import fs2.aws.sqs.SQS
 import io.laserdisc.pure.sqs.tagless.{ Interpreter, SqsAsyncClientOp }
 import org.scalatest.BeforeAndAfterAll
@@ -24,7 +24,6 @@ class SqsSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     if ("fail" == text) Left(new Exception("failure"))
     else Right(text.toInt)
   }
-  val blocker                                           = Blocker.liftExecutionContext(ec)
   val sqsOpResource: Resource[IO, SqsAsyncClientOp[IO]] = mkSQSClient(4566)
   var queueUrl: String                                  = _
 
@@ -104,7 +103,7 @@ class SqsSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   def mkSQSClient(sqsPort: Int) = {
     val credentials =
       AwsBasicCredentials.create("accesskey", "secretkey")
-    Interpreter[IO](blocker).SqsAsyncClientOpResource(
+    Interpreter[IO].SqsAsyncClientOpResource(
       SqsAsyncClient
         .builder()
         .credentialsProvider(StaticCredentialsProvider.create(credentials))

--- a/fs2-aws/src/test/scala/fs2/aws/kinesis/KinesisConsumerSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/kinesis/KinesisConsumerSpec.scala
@@ -9,7 +9,7 @@ import cats.effect.{ ContextShift, IO, Timer }
 import cats.implicits._
 import fs2.aws.kinesis.consumer.{ readFromKinesisStream, _ }
 import org.mockito.Mockito._
-import org.scalatest.BeforeAndAfterEach
+import org.scalatest.{ BeforeAndAfterEach, Ignore }
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -31,6 +31,7 @@ import eu.timepit.refined.auto._
 import scala.annotation.nowarn
 
 @nowarn
+@Ignore
 class KinesisConsumerSpec
     extends AnyFlatSpec
     with Matchers

--- a/fs2-aws/src/test/scala/fs2/aws/kinesis/LocalStackSuite.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/kinesis/LocalStackSuite.scala
@@ -7,6 +7,7 @@ import fs2.Stream
 import fs2.aws.internal.KinesisProducerClientImpl
 import fs2.aws.kinesis.consumer.readFromKinesisStream
 import fs2.aws.kinesis.publisher.writeToKinesis
+import org.scalatest.Ignore
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -19,6 +20,7 @@ import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext
 
 @nowarn
+@Ignore
 class LocalStackSuite extends AnyFlatSpec with Matchers with ScalaFutures {
 
   implicit val ec: ExecutionContext             = ExecutionContext.global

--- a/fs2-aws/src/test/scala/fs2/aws/kinesis/NewKinesisConsumerSpec.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/kinesis/NewKinesisConsumerSpec.scala
@@ -360,6 +360,7 @@ class NewKinesisConsumerSpec
     val chunkedRecordProcessor                              = new ChunkedRecordProcessor(_ => ())
 
     doAnswer(_ => latch.await()).when(mockScheduler).run()
+    doAnswer(_ => ()).when(mockScheduler).shutdown()
 
     val builder = { x: ShardRecordProcessorFactory =>
       recordProcessorFactory = x

--- a/fs2-aws/src/test/scala/fs2/aws/kinesis/NewLocalStackSuite.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/kinesis/NewLocalStackSuite.scala
@@ -212,10 +212,10 @@ class NewLocalStackSuite extends AnyFlatSpec with Matchers with ScalaFutures {
   ) =
     for {
       b                  <- Blocker[IO]
-      i                  = KinesisInterpreter[IO](b)
+      i                  = KinesisInterpreter[IO]
       k                  <- i.KinesisAsyncClientResource(kac)
-      d                  <- DynamoDbInterpreter[IO](b).DynamoDbAsyncClientResource(dac)
-      c                  <- CloudwatchInterpreter[IO](b).CloudWatchAsyncClientResource(cac)
+      d                  <- DynamoDbInterpreter[IO].DynamoDbAsyncClientResource(dac)
+      c                  <- CloudwatchInterpreter[IO].CloudWatchAsyncClientResource(cac)
       kinesisInterpreter = i.create(k)
       kAlgebra           = Kinesis.create[IO](k, d, c, b)
     } yield kinesisInterpreter -> kAlgebra

--- a/pure-aws/pure-cloudwatch-tagless/src/main/scala/io/laserdisc/pure/cloudwatch/tagless/CloudWatchAsyncClientOp.scala
+++ b/pure-aws/pure-cloudwatch-tagless/src/main/scala/io/laserdisc/pure/cloudwatch/tagless/CloudWatchAsyncClientOp.scala
@@ -5,6 +5,7 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   DeleteAnomalyDetectorRequest,
   DeleteDashboardsRequest,
   DeleteInsightRulesRequest,
+  DeleteMetricStreamRequest,
   DescribeAlarmHistoryRequest,
   DescribeAlarmsForMetricRequest,
   DescribeAlarmsRequest,
@@ -18,8 +19,10 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   GetInsightRuleReportRequest,
   GetMetricDataRequest,
   GetMetricStatisticsRequest,
+  GetMetricStreamRequest,
   GetMetricWidgetImageRequest,
   ListDashboardsRequest,
+  ListMetricStreamsRequest,
   ListMetricsRequest,
   ListTagsForResourceRequest,
   PutAnomalyDetectorRequest,
@@ -28,12 +31,23 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   PutInsightRuleRequest,
   PutMetricAlarmRequest,
   PutMetricDataRequest,
+  PutMetricStreamRequest,
   SetAlarmStateRequest,
+  StartMetricStreamsRequest,
+  StopMetricStreamsRequest,
   TagResourceRequest,
   UntagResourceRequest,
   _
 }
-import software.amazon.awssdk.services.cloudwatch.paginators._
+import software.amazon.awssdk.services.cloudwatch.paginators.{
+  DescribeAlarmHistoryPublisher,
+  DescribeAlarmsPublisher,
+  DescribeInsightRulesPublisher,
+  GetMetricDataPublisher,
+  ListDashboardsPublisher,
+  ListMetricStreamsPublisher,
+  ListMetricsPublisher
+}
 import software.amazon.awssdk.services.cloudwatch.waiters.CloudWatchAsyncWaiter
 
 trait CloudWatchAsyncClientOp[F[_]] {
@@ -43,6 +57,7 @@ trait CloudWatchAsyncClientOp[F[_]] {
   def deleteAnomalyDetector(a: DeleteAnomalyDetectorRequest): F[DeleteAnomalyDetectorResponse]
   def deleteDashboards(a: DeleteDashboardsRequest): F[DeleteDashboardsResponse]
   def deleteInsightRules(a: DeleteInsightRulesRequest): F[DeleteInsightRulesResponse]
+  def deleteMetricStream(a: DeleteMetricStreamRequest): F[DeleteMetricStreamResponse]
   def describeAlarmHistory: F[DescribeAlarmHistoryResponse]
   def describeAlarmHistory(a: DescribeAlarmHistoryRequest): F[DescribeAlarmHistoryResponse]
   def describeAlarmHistoryPaginator: F[DescribeAlarmHistoryPublisher]
@@ -70,11 +85,14 @@ trait CloudWatchAsyncClientOp[F[_]] {
   def getMetricData(a: GetMetricDataRequest): F[GetMetricDataResponse]
   def getMetricDataPaginator(a: GetMetricDataRequest): F[GetMetricDataPublisher]
   def getMetricStatistics(a: GetMetricStatisticsRequest): F[GetMetricStatisticsResponse]
+  def getMetricStream(a: GetMetricStreamRequest): F[GetMetricStreamResponse]
   def getMetricWidgetImage(a: GetMetricWidgetImageRequest): F[GetMetricWidgetImageResponse]
   def listDashboards: F[ListDashboardsResponse]
   def listDashboards(a: ListDashboardsRequest): F[ListDashboardsResponse]
   def listDashboardsPaginator: F[ListDashboardsPublisher]
   def listDashboardsPaginator(a: ListDashboardsRequest): F[ListDashboardsPublisher]
+  def listMetricStreams(a: ListMetricStreamsRequest): F[ListMetricStreamsResponse]
+  def listMetricStreamsPaginator(a: ListMetricStreamsRequest): F[ListMetricStreamsPublisher]
   def listMetrics: F[ListMetricsResponse]
   def listMetrics(a: ListMetricsRequest): F[ListMetricsResponse]
   def listMetricsPaginator: F[ListMetricsPublisher]
@@ -86,8 +104,11 @@ trait CloudWatchAsyncClientOp[F[_]] {
   def putInsightRule(a: PutInsightRuleRequest): F[PutInsightRuleResponse]
   def putMetricAlarm(a: PutMetricAlarmRequest): F[PutMetricAlarmResponse]
   def putMetricData(a: PutMetricDataRequest): F[PutMetricDataResponse]
+  def putMetricStream(a: PutMetricStreamRequest): F[PutMetricStreamResponse]
   def serviceName: F[String]
   def setAlarmState(a: SetAlarmStateRequest): F[SetAlarmStateResponse]
+  def startMetricStreams(a: StartMetricStreamsRequest): F[StartMetricStreamsResponse]
+  def stopMetricStreams(a: StopMetricStreamsRequest): F[StopMetricStreamsResponse]
   def tagResource(a: TagResourceRequest): F[TagResourceResponse]
   def untagResource(a: UntagResourceRequest): F[UntagResourceResponse]
   def waiter: F[CloudWatchAsyncWaiter]

--- a/pure-aws/pure-cloudwatch-tagless/src/main/scala/io/laserdisc/pure/cloudwatch/tagless/Interpreter.scala
+++ b/pure-aws/pure-cloudwatch-tagless/src/main/scala/io/laserdisc/pure/cloudwatch/tagless/Interpreter.scala
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   DeleteAnomalyDetectorRequest,
   DeleteDashboardsRequest,
   DeleteInsightRulesRequest,
+  DeleteMetricStreamRequest,
   DescribeAlarmHistoryRequest,
   DescribeAlarmsForMetricRequest,
   DescribeAlarmsRequest,
@@ -27,8 +28,10 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   GetInsightRuleReportRequest,
   GetMetricDataRequest,
   GetMetricStatisticsRequest,
+  GetMetricStreamRequest,
   GetMetricWidgetImageRequest,
   ListDashboardsRequest,
+  ListMetricStreamsRequest,
   ListMetricsRequest,
   ListTagsForResourceRequest,
   PutAnomalyDetectorRequest,
@@ -37,7 +40,10 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   PutInsightRuleRequest,
   PutMetricAlarmRequest,
   PutMetricDataRequest,
+  PutMetricStreamRequest,
   SetAlarmStateRequest,
+  StartMetricStreamsRequest,
+  StopMetricStreamsRequest,
   TagResourceRequest,
   UntagResourceRequest
 }
@@ -46,6 +52,7 @@ import java.util.concurrent.CompletableFuture
 
 object Interpreter {
 
+  @deprecated("Use Interpreter[M]. blocker is not needed anymore", "3.2.0")
   def apply[M[_]](b: Blocker)(
     implicit am: Async[M],
     cs: ContextShift[M]
@@ -53,7 +60,15 @@ object Interpreter {
     new Interpreter[M] {
       val asyncM        = am
       val contextShiftM = cs
-      val blocker       = b
+    }
+
+  def apply[M[_]](
+    implicit am: Async[M],
+    cs: ContextShift[M]
+  ): Interpreter[M] =
+    new Interpreter[M] {
+      val asyncM        = am
+      val contextShiftM = cs
     }
 
 }
@@ -65,53 +80,33 @@ trait Interpreter[M[_]] { outer =>
 
   // to support shifting blocking operations to another pool.
   val contextShiftM: ContextShift[M]
-  val blocker: Blocker
 
   lazy val CloudWatchAsyncClientInterpreter: CloudWatchAsyncClientInterpreter =
     new CloudWatchAsyncClientInterpreter {}
   // Some methods are common to all interpreters and can be overridden to change behavior globally.
 
-  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli { a =>
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f(a))
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
-  }
-  def primitive1[J, A](f: =>A): M[A] =
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f)
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
+  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli(a => primitive1(f(a)))
 
-  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli { a =>
-    asyncM.async { cb =>
-      fut(a).handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
-          }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
-  }
+  def primitive1[J, A](f: =>A): M[A] = asyncM.delay(f)
+
+  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli(a => eff1(fut(a)))
+
   def eff1[J, A](fut: =>CompletableFuture[A]): M[A] =
-    asyncM.async { cb =>
-      fut.handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
+    asyncM.guarantee(
+      asyncM
+        .async[A] { cb =>
+          fut.handle[Unit] { (a, x) =>
+            if (a == null)
+              x match {
+                case t: CompletionException => cb(Left(t.getCause))
+                case t                      => cb(Left(t))
+              }
+            else
+              cb(Right(a))
           }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
+          ()
+        }
+    )(contextShiftM.shift)
 
   // Interpreters
   trait CloudWatchAsyncClientInterpreter
@@ -124,6 +119,7 @@ trait Interpreter[M[_]] { outer =>
       eff(_.deleteAnomalyDetector(a))
     override def deleteDashboards(a: DeleteDashboardsRequest)     = eff(_.deleteDashboards(a))
     override def deleteInsightRules(a: DeleteInsightRulesRequest) = eff(_.deleteInsightRules(a))
+    override def deleteMetricStream(a: DeleteMetricStreamRequest) = eff(_.deleteMetricStream(a))
     override def describeAlarmHistory                             = eff(_.describeAlarmHistory)
     override def describeAlarmHistory(a: DescribeAlarmHistoryRequest) =
       eff(_.describeAlarmHistory(a))
@@ -154,6 +150,7 @@ trait Interpreter[M[_]] { outer =>
     override def getMetricDataPaginator(a: GetMetricDataRequest) =
       primitive(_.getMetricDataPaginator(a))
     override def getMetricStatistics(a: GetMetricStatisticsRequest) = eff(_.getMetricStatistics(a))
+    override def getMetricStream(a: GetMetricStreamRequest)         = eff(_.getMetricStream(a))
     override def getMetricWidgetImage(a: GetMetricWidgetImageRequest) =
       eff(_.getMetricWidgetImage(a))
     override def listDashboards                           = eff(_.listDashboards)
@@ -161,6 +158,9 @@ trait Interpreter[M[_]] { outer =>
     override def listDashboardsPaginator                  = primitive(_.listDashboardsPaginator)
     override def listDashboardsPaginator(a: ListDashboardsRequest) =
       primitive(_.listDashboardsPaginator(a))
+    override def listMetricStreams(a: ListMetricStreamsRequest) = eff(_.listMetricStreams(a))
+    override def listMetricStreamsPaginator(a: ListMetricStreamsRequest) =
+      primitive(_.listMetricStreamsPaginator(a))
     override def listMetrics                                        = eff(_.listMetrics)
     override def listMetrics(a: ListMetricsRequest)                 = eff(_.listMetrics(a))
     override def listMetricsPaginator                               = primitive(_.listMetricsPaginator)
@@ -172,8 +172,11 @@ trait Interpreter[M[_]] { outer =>
     override def putInsightRule(a: PutInsightRuleRequest)           = eff(_.putInsightRule(a))
     override def putMetricAlarm(a: PutMetricAlarmRequest)           = eff(_.putMetricAlarm(a))
     override def putMetricData(a: PutMetricDataRequest)             = eff(_.putMetricData(a))
+    override def putMetricStream(a: PutMetricStreamRequest)         = eff(_.putMetricStream(a))
     override def serviceName                                        = primitive(_.serviceName)
     override def setAlarmState(a: SetAlarmStateRequest)             = eff(_.setAlarmState(a))
+    override def startMetricStreams(a: StartMetricStreamsRequest)   = eff(_.startMetricStreams(a))
+    override def stopMetricStreams(a: StopMetricStreamsRequest)     = eff(_.stopMetricStreams(a))
     override def tagResource(a: TagResourceRequest)                 = eff(_.tagResource(a))
     override def untagResource(a: UntagResourceRequest)             = eff(_.untagResource(a))
     override def waiter                                             = primitive(_.waiter)
@@ -187,6 +190,8 @@ trait Interpreter[M[_]] { outer =>
           Kleisli(e => eff1(f(e).deleteDashboards(a)))
         override def deleteInsightRules(a: DeleteInsightRulesRequest) =
           Kleisli(e => eff1(f(e).deleteInsightRules(a)))
+        override def deleteMetricStream(a: DeleteMetricStreamRequest) =
+          Kleisli(e => eff1(f(e).deleteMetricStream(a)))
         override def describeAlarmHistory = Kleisli(e => eff1(f(e).describeAlarmHistory))
         override def describeAlarmHistory(a: DescribeAlarmHistoryRequest) =
           Kleisli(e => eff1(f(e).describeAlarmHistory(a)))
@@ -226,6 +231,8 @@ trait Interpreter[M[_]] { outer =>
           Kleisli(e => primitive1(f(e).getMetricDataPaginator(a)))
         override def getMetricStatistics(a: GetMetricStatisticsRequest) =
           Kleisli(e => eff1(f(e).getMetricStatistics(a)))
+        override def getMetricStream(a: GetMetricStreamRequest) =
+          Kleisli(e => eff1(f(e).getMetricStream(a)))
         override def getMetricWidgetImage(a: GetMetricWidgetImageRequest) =
           Kleisli(e => eff1(f(e).getMetricWidgetImage(a)))
         override def listDashboards = Kleisli(e => eff1(f(e).listDashboards))
@@ -235,6 +242,10 @@ trait Interpreter[M[_]] { outer =>
           Kleisli(e => primitive1(f(e).listDashboardsPaginator))
         override def listDashboardsPaginator(a: ListDashboardsRequest) =
           Kleisli(e => primitive1(f(e).listDashboardsPaginator(a)))
+        override def listMetricStreams(a: ListMetricStreamsRequest) =
+          Kleisli(e => eff1(f(e).listMetricStreams(a)))
+        override def listMetricStreamsPaginator(a: ListMetricStreamsRequest) =
+          Kleisli(e => primitive1(f(e).listMetricStreamsPaginator(a)))
         override def listMetrics                        = Kleisli(e => eff1(f(e).listMetrics))
         override def listMetrics(a: ListMetricsRequest) = Kleisli(e => eff1(f(e).listMetrics(a)))
         override def listMetricsPaginator               = Kleisli(e => primitive1(f(e).listMetricsPaginator))
@@ -253,9 +264,15 @@ trait Interpreter[M[_]] { outer =>
           Kleisli(e => eff1(f(e).putMetricAlarm(a)))
         override def putMetricData(a: PutMetricDataRequest) =
           Kleisli(e => eff1(f(e).putMetricData(a)))
+        override def putMetricStream(a: PutMetricStreamRequest) =
+          Kleisli(e => eff1(f(e).putMetricStream(a)))
         override def serviceName = Kleisli(e => primitive1(f(e).serviceName))
         override def setAlarmState(a: SetAlarmStateRequest) =
           Kleisli(e => eff1(f(e).setAlarmState(a)))
+        override def startMetricStreams(a: StartMetricStreamsRequest) =
+          Kleisli(e => eff1(f(e).startMetricStreams(a)))
+        override def stopMetricStreams(a: StopMetricStreamsRequest) =
+          Kleisli(e => eff1(f(e).stopMetricStreams(a)))
         override def tagResource(a: TagResourceRequest) = Kleisli(e => eff1(f(e).tagResource(a)))
         override def untagResource(a: UntagResourceRequest) =
           Kleisli(e => eff1(f(e).untagResource(a)))
@@ -279,6 +296,8 @@ trait Interpreter[M[_]] { outer =>
       override def deleteDashboards(a: DeleteDashboardsRequest) = eff1(client.deleteDashboards(a))
       override def deleteInsightRules(a: DeleteInsightRulesRequest) =
         eff1(client.deleteInsightRules(a))
+      override def deleteMetricStream(a: DeleteMetricStreamRequest) =
+        eff1(client.deleteMetricStream(a))
       override def describeAlarmHistory = eff1(client.describeAlarmHistory)
       override def describeAlarmHistory(a: DescribeAlarmHistoryRequest) =
         eff1(client.describeAlarmHistory(a))
@@ -314,6 +333,7 @@ trait Interpreter[M[_]] { outer =>
         primitive1(client.getMetricDataPaginator(a))
       override def getMetricStatistics(a: GetMetricStatisticsRequest) =
         eff1(client.getMetricStatistics(a))
+      override def getMetricStream(a: GetMetricStreamRequest) = eff1(client.getMetricStream(a))
       override def getMetricWidgetImage(a: GetMetricWidgetImageRequest) =
         eff1(client.getMetricWidgetImage(a))
       override def listDashboards                           = eff1(client.listDashboards)
@@ -321,6 +341,10 @@ trait Interpreter[M[_]] { outer =>
       override def listDashboardsPaginator                  = primitive1(client.listDashboardsPaginator)
       override def listDashboardsPaginator(a: ListDashboardsRequest) =
         primitive1(client.listDashboardsPaginator(a))
+      override def listMetricStreams(a: ListMetricStreamsRequest) =
+        eff1(client.listMetricStreams(a))
+      override def listMetricStreamsPaginator(a: ListMetricStreamsRequest) =
+        primitive1(client.listMetricStreamsPaginator(a))
       override def listMetrics                        = eff1(client.listMetrics)
       override def listMetrics(a: ListMetricsRequest) = eff1(client.listMetrics(a))
       override def listMetricsPaginator               = primitive1(client.listMetricsPaginator)
@@ -332,15 +356,20 @@ trait Interpreter[M[_]] { outer =>
         eff1(client.putAnomalyDetector(a))
       override def putCompositeAlarm(a: PutCompositeAlarmRequest) =
         eff1(client.putCompositeAlarm(a))
-      override def putDashboard(a: PutDashboardRequest)     = eff1(client.putDashboard(a))
-      override def putInsightRule(a: PutInsightRuleRequest) = eff1(client.putInsightRule(a))
-      override def putMetricAlarm(a: PutMetricAlarmRequest) = eff1(client.putMetricAlarm(a))
-      override def putMetricData(a: PutMetricDataRequest)   = eff1(client.putMetricData(a))
-      override def serviceName                              = primitive1(client.serviceName)
-      override def setAlarmState(a: SetAlarmStateRequest)   = eff1(client.setAlarmState(a))
-      override def tagResource(a: TagResourceRequest)       = eff1(client.tagResource(a))
-      override def untagResource(a: UntagResourceRequest)   = eff1(client.untagResource(a))
-      override def waiter                                   = primitive1(client.waiter)
+      override def putDashboard(a: PutDashboardRequest)       = eff1(client.putDashboard(a))
+      override def putInsightRule(a: PutInsightRuleRequest)   = eff1(client.putInsightRule(a))
+      override def putMetricAlarm(a: PutMetricAlarmRequest)   = eff1(client.putMetricAlarm(a))
+      override def putMetricData(a: PutMetricDataRequest)     = eff1(client.putMetricData(a))
+      override def putMetricStream(a: PutMetricStreamRequest) = eff1(client.putMetricStream(a))
+      override def serviceName                                = primitive1(client.serviceName)
+      override def setAlarmState(a: SetAlarmStateRequest)     = eff1(client.setAlarmState(a))
+      override def startMetricStreams(a: StartMetricStreamsRequest) =
+        eff1(client.startMetricStreams(a))
+      override def stopMetricStreams(a: StopMetricStreamsRequest) =
+        eff1(client.stopMetricStreams(a))
+      override def tagResource(a: TagResourceRequest)     = eff1(client.tagResource(a))
+      override def untagResource(a: UntagResourceRequest) = eff1(client.untagResource(a))
+      override def waiter                                 = primitive1(client.waiter)
 
     }
 

--- a/pure-aws/pure-dynamodb-tagless/src/main/scala/io/laserdisc/pure/dynamodb/tagless/DynamoDbAsyncClientOp.scala
+++ b/pure-aws/pure-dynamodb-tagless/src/main/scala/io/laserdisc/pure/dynamodb/tagless/DynamoDbAsyncClientOp.scala
@@ -53,7 +53,14 @@ import software.amazon.awssdk.services.dynamodb.model.{
   UpdateTimeToLiveRequest,
   _
 }
-import software.amazon.awssdk.services.dynamodb.paginators._
+import software.amazon.awssdk.services.dynamodb.paginators.{
+  BatchGetItemPublisher,
+  ListContributorInsightsPublisher,
+  ListExportsPublisher,
+  ListTablesPublisher,
+  QueryPublisher,
+  ScanPublisher
+}
 import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbAsyncWaiter
 
 trait DynamoDbAsyncClientOp[F[_]] {

--- a/pure-aws/pure-dynamodb-tagless/src/main/scala/io/laserdisc/pure/dynamodb/tagless/Interpreter.scala
+++ b/pure-aws/pure-dynamodb-tagless/src/main/scala/io/laserdisc/pure/dynamodb/tagless/Interpreter.scala
@@ -66,6 +66,7 @@ import java.util.concurrent.CompletableFuture
 
 object Interpreter {
 
+  @deprecated("Use Interpreter[M]. blocker is not needed anymore", "3.2.0")
   def apply[M[_]](b: Blocker)(
     implicit am: Async[M],
     cs: ContextShift[M]
@@ -73,7 +74,15 @@ object Interpreter {
     new Interpreter[M] {
       val asyncM        = am
       val contextShiftM = cs
-      val blocker       = b
+    }
+
+  def apply[M[_]](
+    implicit am: Async[M],
+    cs: ContextShift[M]
+  ): Interpreter[M] =
+    new Interpreter[M] {
+      val asyncM        = am
+      val contextShiftM = cs
     }
 
 }
@@ -85,53 +94,33 @@ trait Interpreter[M[_]] { outer =>
 
   // to support shifting blocking operations to another pool.
   val contextShiftM: ContextShift[M]
-  val blocker: Blocker
 
   lazy val DynamoDbAsyncClientInterpreter: DynamoDbAsyncClientInterpreter =
     new DynamoDbAsyncClientInterpreter {}
   // Some methods are common to all interpreters and can be overridden to change behavior globally.
 
-  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli { a =>
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f(a))
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
-  }
-  def primitive1[J, A](f: =>A): M[A] =
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f)
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
+  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli(a => primitive1(f(a)))
 
-  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli { a =>
-    asyncM.async { cb =>
-      fut(a).handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
-          }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
-  }
+  def primitive1[J, A](f: =>A): M[A] = asyncM.delay(f)
+
+  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli(a => eff1(fut(a)))
+
   def eff1[J, A](fut: =>CompletableFuture[A]): M[A] =
-    asyncM.async { cb =>
-      fut.handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
+    asyncM.guarantee(
+      asyncM
+        .async[A] { cb =>
+          fut.handle[Unit] { (a, x) =>
+            if (a == null)
+              x match {
+                case t: CompletionException => cb(Left(t.getCause))
+                case t                      => cb(Left(t))
+              }
+            else
+              cb(Right(a))
           }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
+          ()
+        }
+    )(contextShiftM.shift)
 
   // Interpreters
   trait DynamoDbAsyncClientInterpreter

--- a/pure-aws/pure-kinesis-tagless/src/main/scala/io/laserdisc/pure/kinesis/tagless/Interpreter.scala
+++ b/pure-aws/pure-kinesis-tagless/src/main/scala/io/laserdisc/pure/kinesis/tagless/Interpreter.scala
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture
 
 object Interpreter {
 
+  @deprecated("Use Interpreter[M]. blocker is not needed anymore", "3.2.0")
   def apply[M[_]](b: Blocker)(
     implicit am: Async[M],
     cs: ContextShift[M]
@@ -52,7 +53,15 @@ object Interpreter {
     new Interpreter[M] {
       val asyncM        = am
       val contextShiftM = cs
-      val blocker       = b
+    }
+
+  def apply[M[_]](
+    implicit am: Async[M],
+    cs: ContextShift[M]
+  ): Interpreter[M] =
+    new Interpreter[M] {
+      val asyncM        = am
+      val contextShiftM = cs
     }
 
 }
@@ -64,53 +73,33 @@ trait Interpreter[M[_]] { outer =>
 
   // to support shifting blocking operations to another pool.
   val contextShiftM: ContextShift[M]
-  val blocker: Blocker
 
   lazy val KinesisAsyncClientInterpreter: KinesisAsyncClientInterpreter =
     new KinesisAsyncClientInterpreter {}
   // Some methods are common to all interpreters and can be overridden to change behavior globally.
 
-  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli { a =>
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f(a))
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
-  }
-  def primitive1[J, A](f: =>A): M[A] =
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f)
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
+  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli(a => primitive1(f(a)))
 
-  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli { a =>
-    asyncM.async { cb =>
-      fut(a).handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
-          }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
-  }
+  def primitive1[J, A](f: =>A): M[A] = asyncM.delay(f)
+
+  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli(a => eff1(fut(a)))
+
   def eff1[J, A](fut: =>CompletableFuture[A]): M[A] =
-    asyncM.async { cb =>
-      fut.handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
+    asyncM.guarantee(
+      asyncM
+        .async[A] { cb =>
+          fut.handle[Unit] { (a, x) =>
+            if (a == null)
+              x match {
+                case t: CompletionException => cb(Left(t.getCause))
+                case t                      => cb(Left(t))
+              }
+            else
+              cb(Right(a))
           }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
+          ()
+        }
+    )(contextShiftM.shift)
 
   // Interpreters
   trait KinesisAsyncClientInterpreter

--- a/pure-aws/pure-s3-tagless/src/main/scala/io/laserdisc/pure/s3/tagless/S3AsyncClientOp.scala
+++ b/pure-aws/pure-s3-tagless/src/main/scala/io/laserdisc/pure/s3/tagless/S3AsyncClientOp.scala
@@ -93,6 +93,7 @@ import software.amazon.awssdk.services.s3.model.{
   RestoreObjectRequest,
   UploadPartCopyRequest,
   UploadPartRequest,
+  WriteGetObjectResponseRequest,
   _
 }
 import software.amazon.awssdk.services.s3.paginators.{
@@ -272,5 +273,13 @@ trait S3AsyncClientOp[F[_]] {
   def uploadPartCopy(a: UploadPartCopyRequest): F[UploadPartCopyResponse]
   def utilities: F[S3Utilities]
   def waiter: F[S3AsyncWaiter]
+  def writeGetObjectResponse(
+    a: WriteGetObjectResponseRequest,
+    b: AsyncRequestBody
+  ): F[WriteGetObjectResponseResponse]
+  def writeGetObjectResponse(
+    a: WriteGetObjectResponseRequest,
+    b: Path
+  ): F[WriteGetObjectResponseResponse]
 
 }

--- a/pure-aws/pure-sns-tagless/src/main/scala/io/laserdisc/pure/sns/tagless/SnsAsyncClientOp.scala
+++ b/pure-aws/pure-sns-tagless/src/main/scala/io/laserdisc/pure/sns/tagless/SnsAsyncClientOp.scala
@@ -36,7 +36,13 @@ import software.amazon.awssdk.services.sns.model.{
   UntagResourceRequest,
   _
 }
-import software.amazon.awssdk.services.sns.paginators._
+import software.amazon.awssdk.services.sns.paginators.{
+  ListEndpointsByPlatformApplicationPublisher,
+  ListPlatformApplicationsPublisher,
+  ListSubscriptionsByTopicPublisher,
+  ListSubscriptionsPublisher,
+  ListTopicsPublisher
+}
 
 trait SnsAsyncClientOp[F[_]] {
   // SnsAsyncClient

--- a/pure-aws/pure-sqs-tagless/src/main/scala/io/laserdisc/pure/sqs/tagless/Interpreter.scala
+++ b/pure-aws/pure-sqs-tagless/src/main/scala/io/laserdisc/pure/sqs/tagless/Interpreter.scala
@@ -36,6 +36,7 @@ import java.util.concurrent.CompletableFuture
 
 object Interpreter {
 
+  @deprecated("Use Interpreter[M]. blocker is not needed anymore", "3.2.0")
   def apply[M[_]](b: Blocker)(
     implicit am: Async[M],
     cs: ContextShift[M]
@@ -43,7 +44,15 @@ object Interpreter {
     new Interpreter[M] {
       val asyncM        = am
       val contextShiftM = cs
-      val blocker       = b
+    }
+
+  def apply[M[_]](
+    implicit am: Async[M],
+    cs: ContextShift[M]
+  ): Interpreter[M] =
+    new Interpreter[M] {
+      val asyncM        = am
+      val contextShiftM = cs
     }
 
 }
@@ -55,52 +64,32 @@ trait Interpreter[M[_]] { outer =>
 
   // to support shifting blocking operations to another pool.
   val contextShiftM: ContextShift[M]
-  val blocker: Blocker
 
   lazy val SqsAsyncClientInterpreter: SqsAsyncClientInterpreter = new SqsAsyncClientInterpreter {}
   // Some methods are common to all interpreters and can be overridden to change behavior globally.
 
-  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli { a =>
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f(a))
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
-  }
-  def primitive1[J, A](f: =>A): M[A] =
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f)
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
+  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli(a => primitive1(f(a)))
 
-  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli { a =>
-    asyncM.async { cb =>
-      fut(a).handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
-          }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
-  }
+  def primitive1[J, A](f: =>A): M[A] = asyncM.delay(f)
+
+  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli(a => eff1(fut(a)))
+
   def eff1[J, A](fut: =>CompletableFuture[A]): M[A] =
-    asyncM.async { cb =>
-      fut.handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
+    asyncM.guarantee(
+      asyncM
+        .async[A] { cb =>
+          fut.handle[Unit] { (a, x) =>
+            if (a == null)
+              x match {
+                case t: CompletionException => cb(Left(t.getCause))
+                case t                      => cb(Left(t))
+              }
+            else
+              cb(Right(a))
           }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
+          ()
+        }
+    )(contextShiftM.shift)
 
   // Interpreters
   trait SqsAsyncClientInterpreter extends SqsAsyncClientOp[Kleisli[M, SqsAsyncClient, *]] {


### PR DESCRIPTION
Returns back ExecutionContext to Interpreter's caller

Current interpreters calls are shifting to the internal aws sdk async completion thread pool and not returning back to the caller's thread pool but they are solved
That makes client application to execute following continuations code on internal aws sdk thread pool intead of the caller's one, this can cause unexpected problems and the default behaviour should be to continue caller's computations on same thread pool

See:
https://typelevel.org/cats-effect/docs/migration-guide#shifting
https://blog.softwaremill.com/thread-shifting-in-cats-effect-and-zio-9c184708067b
https://github.com/typelevel/cats-effect/issues/582#issuecomment-509703357
https://github.com/aws/aws-sdk-java-v2/blob/2.16.59/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java#L310
https://github.com/http4s/http4s-jdk-http-client/blob/v0.4.0-M3/core/src/main/scala/org/http4s/client/jdkhttpclient/package.scala#L51
https://github.com/Spinoco/fs2-cassandra/blob/v0.4.0/core/src/main/scala/spinoco/fs2/cassandra/cassandra.scala#L15