### PR TITLE
Add sts dependency to fs2-aws-s3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,6 +130,7 @@ lazy val `fs2-aws-s3` = (project in file("fs2-aws-s3"))
       "co.fs2"                %% "fs2-io"              % V.Fs2,
       "eu.timepit"            %% "refined"             % V.Refined,
       "software.amazon.awssdk" % "s3"                  % V.AwsSdk,
+      "software.amazon.awssdk" % "sts"                 % V.AwsSdk,
       "org.scalameta"         %% "munit"               % V.Munit % Test,
       "org.typelevel"         %% "munit-cats-effect-3" % "1.0.7" % Test
     ),


### PR DESCRIPTION
## Added sts dependency to fs2-aws-s3

We widely use assume roles when performing s3 operations. So far, we have manually added the sts library to our project dependencies but it would be nice if it comes within this library so we don't need to worry about aws client versions.

What's the rationale for sts being part of some of the modules and not all of them as a `fs2-aws-core` dependency?