### PR TITLE
remove sts dependency from kinesis module. It is user responsibility …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,6 @@ lazy val `fs2-aws-kinesis` = (project in file("fs2-aws-kinesis"))
       "co.fs2"                 %% "fs2-io"                  % V.Fs2,
       "com.amazonaws"           % "amazon-kinesis-producer" % "0.14.11",
       "software.amazon.kinesis" % "amazon-kinesis-client"   % "2.4.2",
-      "software.amazon.awssdk"  % "sts"                     % V.AwsSdk,
       "eu.timepit"             %% "refined"                 % V.Refined,
       "org.scalatest"          %% "scalatest"               % V.ScalaTest   % Test,
       "org.mockito"             % "mockito-core"            % V.MockitoCore % Test,


### PR DESCRIPTION
…to cook the AWS SDK client and pass it to the pure-aws constructs