### PR TITLE
Update Ciris to 3.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ ThisBuild / crossScalaVersions := supportedScalaVersions
 
 ThisBuild / scalaVersion := scala3
 
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+
 lazy val root = (project in file("."))
   .aggregate(
     `fs2-aws-kinesis`,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,8 +18,7 @@ object Dependencies {
     val SLF4J            = "2.0.3"
     val Log4Cats         = "2.5.0"
 
-    // TODO: https://github.com/vlovgr/ciris/releases/tag/v2.4.0 requires a move to scala 3.2.0 (binary incompatible, it appears)
-    val Ciris = "2.3.3"
+    val Ciris = "3.0.0"
   }
 
   val Ciris = libraryDependencies += "is.cir" %% "ciris" % V.Ciris

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 //addSbtPlugin("ch.epfl.scala" % "sbt-scala3-migrate" % "0.5.0")
 
 addDependencyTreePlugin
+
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
Resolves #944 without removing Ciris or upgrading Scala to 3.2.x. This should have a longer term viability as other projects upgrade to 3.2.x, if fs2-aws chooses to remain on 3.1.x.

Ciris's upgrade does bring in a scala-xml dependency upgrade, but it is safe to ignore the version scheme for it per many discussions.

See https://github.com/sbt/sbt/issues/6997 and https://github.com/scala/scala/pull/9743 as a discussion point on this, which includes references to this workaround.