### PR TITLE
Change PartSizeMB to `GreaterEqual[5]`

### DIFF
--- a/fs2-aws-s3/src/main/scala-3.0+/fs2/aws/s3/models/Models.scala
+++ b/fs2-aws-s3/src/main/scala-3.0+/fs2/aws/s3/models/Models.scala
@@ -1,16 +1,14 @@
 package fs2.aws.s3.models
 
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
-import eu.timepit.refined.boolean.Or
-import eu.timepit.refined.generic.Equal
-import eu.timepit.refined.numeric.Greater
+import eu.timepit.refined.numeric.GreaterEqual
 import eu.timepit.refined.types.string.NonEmptyString
 
 object Models {
 
   // Each part must be at least 5 MB in size
   // https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#uploadPart-software.amazon.awssdk.services.s3.model.UploadPartRequest-software.amazon.awssdk.core.sync.RequestBody-
-  type PartSizeMB = Int Refined (Greater[5] Or Equal[5])
+  type PartSizeMB = Int Refined GreaterEqual[5]
   type ETag       = String
 
   object PartSizeMB extends RefinedTypeOps.Numeric[PartSizeMB, Int]

--- a/fs2-aws-s3/src/main/scala-3.0-/fs2/aws/s3/models/Models.scala
+++ b/fs2-aws-s3/src/main/scala-3.0-/fs2/aws/s3/models/Models.scala
@@ -2,16 +2,14 @@ package fs2.aws.s3.models
 
 import eu.timepit.refined.W
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
-import eu.timepit.refined.boolean.Or
-import eu.timepit.refined.generic.Equal
-import eu.timepit.refined.numeric.Greater
+import eu.timepit.refined.numeric.GreaterEqual
 import eu.timepit.refined.types.string.NonEmptyString
 
 object Models {
 
   // Each part must be at least 5 MB in size
   // https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#uploadPart-software.amazon.awssdk.services.s3.model.UploadPartRequest-software.amazon.awssdk.core.sync.RequestBody-
-  type PartSizeMB = Int Refined (Greater[W.`5`.T] Or Equal[W.`5`.T])
+  type PartSizeMB = Int Refined GreaterEqual[W.`5`.T]
   type ETag       = String
 
   object PartSizeMB extends RefinedTypeOps.Numeric[PartSizeMB, Int]


### PR DESCRIPTION
This change avoids a bug in refined (https://github.com/fthomas/refined/issues/1161) that caused PartSizeMB a long time to be initialized.

Although that bug will probably be fixed soon, the use of `GreaterEqual` is preferred over `Greater Or Equal`.