### PR TITLE
Fix issue with empty streams and multipart upload

### DIFF
--- a/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/DynamoDB.scala
+++ b/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/DynamoDB.scala
@@ -76,7 +76,7 @@ object DynamoDB {
       // Instantiate a new bounded queue and concurrently run the queue populator
       // Expose the elements by dequeuing the internal buffer
       for {
-        dispatcher      <- Stream.resource(Dispatcher.parallel[F])
+        dispatcher      <- Stream.resource(Dispatcher.parallel[F](await = true))
         buffer          <- Stream.eval(Queue.unbounded[F, CommittableRecord])
         interruptSignal <- Stream.eval(SignallingRef[F, Boolean](false))
         _               <- instantiateScheduler(dispatcher, buffer, interruptSignal)

--- a/fs2-aws-s3/src/main/scala-3.0+/fs2/aws/s3/models/Models.scala
+++ b/fs2-aws-s3/src/main/scala-3.0+/fs2/aws/s3/models/Models.scala
@@ -8,8 +8,9 @@ object Models {
 
   // Each part must be at least 5 MB in size
   // https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#uploadPart-software.amazon.awssdk.services.s3.model.UploadPartRequest-software.amazon.awssdk.core.sync.RequestBody-
-  type PartSizeMB = Int Refined GreaterEqual[5]
-  type ETag       = String
+  type PartSizeMB       = Int Refined GreaterEqual[5]
+  type ETag             = String
+  type UploadEmptyFiles = Boolean
 
   object PartSizeMB extends RefinedTypeOps.Numeric[PartSizeMB, Int]
 

--- a/fs2-aws-s3/src/main/scala-3.0+/fs2/aws/s3/models/Models.scala
+++ b/fs2-aws-s3/src/main/scala-3.0+/fs2/aws/s3/models/Models.scala
@@ -8,9 +8,10 @@ object Models {
 
   // Each part must be at least 5 MB in size
   // https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#uploadPart-software.amazon.awssdk.services.s3.model.UploadPartRequest-software.amazon.awssdk.core.sync.RequestBody-
-  type PartSizeMB       = Int Refined GreaterEqual[5]
-  type ETag             = String
-  type UploadEmptyFiles = Boolean
+  type PartSizeMB           = Int Refined GreaterEqual[5]
+  type ETag                 = String
+  type UploadEmptyFiles     = Boolean
+  type MultiPartConcurrency = Int
 
   object PartSizeMB extends RefinedTypeOps.Numeric[PartSizeMB, Int]
 

--- a/fs2-aws-s3/src/main/scala-3.0-/fs2/aws/s3/models/Models.scala
+++ b/fs2-aws-s3/src/main/scala-3.0-/fs2/aws/s3/models/Models.scala
@@ -9,8 +9,9 @@ object Models {
 
   // Each part must be at least 5 MB in size
   // https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#uploadPart-software.amazon.awssdk.services.s3.model.UploadPartRequest-software.amazon.awssdk.core.sync.RequestBody-
-  type PartSizeMB = Int Refined GreaterEqual[W.`5`.T]
-  type ETag       = String
+  type PartSizeMB      = Int Refined GreaterEqual[W.`5`.T]
+  type ETag            = String
+  type UploadEmptyFiles = Boolean
 
   object PartSizeMB extends RefinedTypeOps.Numeric[PartSizeMB, Int]
 

--- a/fs2-aws-s3/src/main/scala-3.0-/fs2/aws/s3/models/Models.scala
+++ b/fs2-aws-s3/src/main/scala-3.0-/fs2/aws/s3/models/Models.scala
@@ -9,8 +9,8 @@ object Models {
 
   // Each part must be at least 5 MB in size
   // https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#uploadPart-software.amazon.awssdk.services.s3.model.UploadPartRequest-software.amazon.awssdk.core.sync.RequestBody-
-  type PartSizeMB      = Int Refined GreaterEqual[W.`5`.T]
-  type ETag            = String
+  type PartSizeMB       = Int Refined GreaterEqual[W.`5`.T]
+  type ETag             = String
   type UploadEmptyFiles = Boolean
 
   object PartSizeMB extends RefinedTypeOps.Numeric[PartSizeMB, Int]

--- a/fs2-aws-s3/src/main/scala-3.0-/fs2/aws/s3/models/Models.scala
+++ b/fs2-aws-s3/src/main/scala-3.0-/fs2/aws/s3/models/Models.scala
@@ -9,9 +9,10 @@ object Models {
 
   // Each part must be at least 5 MB in size
   // https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#uploadPart-software.amazon.awssdk.services.s3.model.UploadPartRequest-software.amazon.awssdk.core.sync.RequestBody-
-  type PartSizeMB       = Int Refined GreaterEqual[W.`5`.T]
-  type ETag             = String
-  type UploadEmptyFiles = Boolean
+  type PartSizeMB           = Int Refined GreaterEqual[W.`5`.T]
+  type ETag                 = String
+  type UploadEmptyFiles     = Boolean
+  type MultiPartConcurrency = Int
 
   object PartSizeMB extends RefinedTypeOps.Numeric[PartSizeMB, Int]
 

--- a/fs2-aws-s3/src/main/scala/fs2/aws/s3/S3.scala
+++ b/fs2-aws-s3/src/main/scala/fs2/aws/s3/S3.scala
@@ -4,7 +4,7 @@ import cats.effect.*
 import cats.implicits.*
 import cats.~>
 import eu.timepit.refined.auto.*
-import fs2.aws.s3.models.Models.{BucketName, ETag, FileKey, PartSizeMB}
+import fs2.aws.s3.models.Models.{BucketName, ETag, FileKey, PartSizeMB, UploadEmptyFiles}
 import fs2.{Chunk, Pipe, Pull}
 import io.laserdisc.pure.s3.tagless.S3AsyncClientOp
 import software.amazon.awssdk.core.async.{AsyncRequestBody, AsyncResponseTransformer}
@@ -23,8 +23,9 @@ trait S3[F[_]] {
   def uploadFileMultipart(
       bucket: BucketName,
       key: FileKey,
-      partSize: PartSizeMB
-  ): Pipe[F, Byte, ETag]
+      partSize: PartSizeMB,
+      uploadEmptyFiles: UploadEmptyFiles = false
+  ): Pipe[F, Byte, Option[ETag]]
   def readFile(bucket: BucketName, key: FileKey): fs2.Stream[F, Byte]
 
   def readFileMultipart(
@@ -75,6 +76,15 @@ object S3 {
         * It does so in constant memory. So at a given time, only the number of bytes indicated by @partSize
         * will be loaded in memory.
         *
+        * Note: AWS S3 API does not support uploading empty files via multipart upload. It does not gracefully
+        * respond on attempting to do this and returns a `400` response with a generic error message. This function
+        * accepts a boolean `uploadEmptyFile` (set to `false` by default) to determine how to handle this scenario. If
+        * set to false (default) and no data has passed through the stream, it will gracefully abort the multi-part
+        * upload request. If set to true, and no data has passed through the stream, an empty file will be uploaded on
+        * completion. An `Option[ETag]` of `None` will be emitted on the stream if no file was uploaded, else a
+        * `Some(ETag)` will be emitted. Alternatively, If you need to create empty files, consider using consider using
+        * [[uploadFile]] instead.
+        *
         * For small files, consider using [[uploadFile]] instead.
         *
         * @param partSize the part size indicated in MBs. It must be at least 5, as required by AWS.
@@ -82,8 +92,9 @@ object S3 {
       def uploadFileMultipart(
           bucket: BucketName,
           key: FileKey,
-          partSize: PartSizeMB
-      ): Pipe[F, Byte, ETag] = {
+          partSize: PartSizeMB,
+          uploadEmptyFiles: UploadEmptyFiles
+      ): Pipe[F, Byte, Option[ETag]] = {
         val chunkSizeBytes = partSize * 1048576
 
         def initiateMultipartUpload: F[UploadId] =
@@ -106,20 +117,31 @@ object S3 {
             ).map(_.eTag() -> i.toInt)
           }
 
-        def completeUpload(uploadId: UploadId): Pipe[F, List[(PartETag, PartId)], ETag] =
+        def completeUpload(uploadId: UploadId): Pipe[F, List[(PartETag, PartId)], Option[ETag]] =
           _.evalMap { tags =>
-            val parts = tags.map { case (t, i) =>
-              CompletedPart.builder().partNumber(i).eTag(t).build()
-            }.asJava
-            s3.completeMultipartUpload(
-              CompleteMultipartUploadRequest
-                .builder()
-                .bucket(bucket.value)
-                .key(key.value)
-                .uploadId(uploadId)
-                .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build())
-                .build()
-            ).map(_.eTag())
+            if (tags.nonEmpty) {
+              val parts = tags.map { case (t, i) =>
+                CompletedPart.builder().partNumber(i).eTag(t).build()
+              }.asJava
+              s3.completeMultipartUpload(
+                CompleteMultipartUploadRequest
+                  .builder()
+                  .bucket(bucket.value)
+                  .key(key.value)
+                  .uploadId(uploadId)
+                  .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build())
+                  .build()
+              ).map(eTag => Option.apply[ETag](eTag.eTag()))
+            } else {
+              if (uploadEmptyFiles) {
+                s3.putObject(
+                  PutObjectRequest.builder().bucket(bucket.value).key(key.value).build(),
+                  AsyncRequestBody.fromBytes(new Array[Byte](0))
+                ).map(eTag => Option.apply[ETag](eTag.eTag()))
+              } else {
+                cancelUpload(uploadId).map(_ => Option.empty[ETag])
+              }
+            }
           }
 
         def cancelUpload(uploadId: UploadId): F[Unit] =
@@ -141,7 +163,7 @@ object S3 {
                 .through(uploadPart(uploadId))
                 .fold[List[(PartETag, PartId)]](List.empty)(_ :+ _)
                 .through(completeUpload(uploadId))
-                .handleErrorWith(ex => fs2.Stream.eval(cancelUpload(uploadId) >> Sync[F].raiseError[ETag](ex)))
+                .handleErrorWith(ex => fs2.Stream.eval(cancelUpload(uploadId) >> Sync[F].raiseError(ex)))
             }
       }
 
@@ -232,10 +254,11 @@ object S3 {
       override def uploadFileMultipart(
           bucket: BucketName,
           key: FileKey,
-          partSize: PartSizeMB
-      ): Pipe[G, Byte, ETag] =
+          partSize: PartSizeMB,
+          uploadEmptyFiles: UploadEmptyFiles
+      ): Pipe[G, Byte, Option[ETag]] =
         _.translate(gToF)
-          .through(s3.uploadFileMultipart(bucket, key, partSize))
+          .through(s3.uploadFileMultipart(bucket, key, partSize, uploadEmptyFiles))
           .translate(fToG)
 
       override def readFile(bucket: BucketName, key: FileKey): fs2.Stream[G, Byte] =

--- a/fs2-aws-s3/src/test/scala/fs2/aws/s3/S3Suite.scala
+++ b/fs2-aws-s3/src/test/scala/fs2/aws/s3/S3Suite.scala
@@ -10,10 +10,11 @@ import io.laserdisc.pure.s3.tagless.{Interpreter, S3AsyncClientOp}
 import munit.CatsEffectSuite
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.model.{ListMultipartUploadsRequest, NoSuchKeyException}
 import software.amazon.awssdk.services.s3.{S3AsyncClient, S3Configuration}
 
 import java.net.{URI, URL}
+import java.util.UUID
 
 class S3Suite extends CatsEffectSuite {
 
@@ -139,47 +140,60 @@ class S3Suite extends CatsEffectSuite {
     "Gracefully abort multipart upload when no data has been passed through the stream and `uploadEmptyFile` is disabled."
   ) {
 
-    s3R.use { s3 =>
-      s3R.map(S3.create[IO](_)).use { s3 =>
-        val fileKey = FileKey(NonEmptyString.unsafeFrom("jsontest-multipart-upload-empty-file-disabled.json"))
-
-        fs2.Stream.empty
-          .through(s3.uploadFileMultipart(bucket, fileKey, partSize, uploadEmptyFiles = false))
+    s3R.map(s3 => s3 -> S3.create[IO](s3)).use { case (s3Ops, s3) =>
+      for {
+        fileKey <- IO.delay(UUID.randomUUID().toString).map(k => FileKey(NonEmptyString.unsafeFrom(k)))
+        uploadedTags <- fs2.Stream.empty
+          .through(s3.uploadFileMultipart(bucket, fileKey, partSize))
           .compile
           .last
           .map(_.get)
-          .map { res =>
-            assert(res.isEmpty)
-          }
+        activeUploads <- s3Ops
+          .listMultipartUploads(
+            ListMultipartUploadsRequest
+              .builder()
+              .bucket(bucket.value.value)
+              .prefix(fileKey.value.value)
+              .build()
+          )
+          .map(_.uploads())
+      } yield {
+        assert(uploadedTags.isEmpty)
+        assert(activeUploads.isEmpty)
       }
     }
   }
 
-  test("Upload an empty file when using multipart upload when no data has been passed through the stream and `uploadEmptyFile` is enabled.") {
+  test(
+    "upload an empty file when using multipart upload when no data has been passed through the stream and `uploademptyfile` is enabled."
+  ) {
 
-    s3R.use { s3 =>
-      s3R.map(S3.create[IO](_)).use { s3 =>
-        val fileKey = FileKey(NonEmptyString.unsafeFrom("jsontest-multipart-upload-empty-file-enabled.json"))
-
-        val upload = fs2.Stream.empty
+    s3R.map(s3 => s3 -> S3.create[IO](s3)).use { case (s3Ops, s3) =>
+      for {
+        fileKey <- IO.delay(UUID.randomUUID().toString).map(k => FileKey(NonEmptyString.unsafeFrom(k)))
+        uploadedTags <- fs2.Stream.empty
           .through(s3.uploadFileMultipart(bucket, fileKey, partSize, uploadEmptyFiles = true))
           .compile
           .last
           .map(_.get)
-          .map { res =>
-            assert(res.nonEmpty)
-          }
-
-        val read =
-          s3.readFile(bucket, fileKey)
-            .compile
-            .toVector
-            .map(_.toArray)
-            .map { res =>
-              res.isEmpty
-            }
-
-        upload >> read
+        read <- s3
+          .readFile(bucket, fileKey)
+          .compile
+          .toVector
+          .map(_.toArray)
+        activeUploads <- s3Ops
+          .listMultipartUploads(
+            ListMultipartUploadsRequest
+              .builder()
+              .bucket(bucket.value.value)
+              .prefix(fileKey.value.value)
+              .build()
+          )
+          .map(_.uploads())
+      } yield {
+        assert(uploadedTags.nonEmpty)
+        assert(read.isEmpty)
+        assert(activeUploads.isEmpty)
       }
     }
   }

--- a/fs2-aws-s3/src/test/scala/fs2/aws/s3/S3Suite.scala
+++ b/fs2-aws-s3/src/test/scala/fs2/aws/s3/S3Suite.scala
@@ -141,10 +141,10 @@ class S3Suite extends CatsEffectSuite {
 
     s3R.use { s3 =>
       s3R.map(S3.create[IO](_)).use { s3 =>
-        val fileKeyMultipart = FileKey(NonEmptyString.unsafeFrom("jsontest-multipart.json"))
+        val fileKey = FileKey(NonEmptyString.unsafeFrom("jsontest-multipart-upload-empty-file-disabled.json"))
 
         fs2.Stream.empty
-          .through(s3.uploadFileMultipart(bucket, fileKeyMultipart, partSize, uploadEmptyFiles = false))
+          .through(s3.uploadFileMultipart(bucket, fileKey, partSize, uploadEmptyFiles = false))
           .compile
           .last
           .map(_.get)
@@ -155,7 +155,7 @@ class S3Suite extends CatsEffectSuite {
     }
   }
 
-  test("Upload an empty file when no data has been passed through the stream and `uploadEmptyFile` is enabled.") {
+  test("Upload an empty file when using multipart upload when no data has been passed through the stream and `uploadEmptyFile` is enabled.") {
 
     s3R.use { s3 =>
       s3R.map(S3.create[IO](_)).use { s3 =>

--- a/fs2-aws-s3/src/test/scala/fs2/aws/s3/S3Suite.scala
+++ b/fs2-aws-s3/src/test/scala/fs2/aws/s3/S3Suite.scala
@@ -78,7 +78,7 @@ class S3Suite extends CatsEffectSuite {
           Files[IO]
             .readAll(Path(testFile.getPath), 4096, Flags.Read)
             .through(
-              s3.uploadFileMultipart(bucket, fileKeyMix, partSize, uploadEmptyFiles = false)
+              s3.uploadFileMultipart(bucket, fileKeyMix, partSize)
             )
             .compile
             .drain
@@ -114,7 +114,7 @@ class S3Suite extends CatsEffectSuite {
         val upload =
           Files[IO]
             .readAll(Path(testFile.getPath), 4096, Flags.Read)
-            .through(s3.uploadFileMultipart(bucket, fileKeyMultipart, partSize, uploadEmptyFiles = false))
+            .through(s3.uploadFileMultipart(bucket, fileKeyMultipart, partSize))
             .compile
             .drain
 


### PR DESCRIPTION
This PR fixes #723 

It seems the AWS SDK V2 S3 API does not support uploading empty files via multipart upload. It also does not respond the user a meaningful error message.

Compare the following requests are that sent to S3 on completion of a multipart upload. The first is when data was uploaded, and the second when no data/empty file was attempted to be uploaded.
```
<?xml version="1.0" encoding="UTF-8"?>
<CompleteMultipartUpload
    xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <Part>
        <ETag>&quot;a0b307dc9a2c8ef6297fbf0e07dd5758&quot;</ETag>
        <PartNumber>1</PartNumber>
    </Part>
</CompleteMultipartUpload>
```

```
<?xml version="1.0" encoding="UTF-8"?>
<CompleteMultipartUpload
    xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
</CompleteMultipartUpload>
```

However the second request will result in a response from S3:
```
software.amazon.awssdk.services.s3.model.S3Exception: The XML you provided was not well-formed or did not validate against our published schema. (Service: S3, Status Code: 400, Request ID: 175977D7C4F19E5B, Extended Request ID: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855)

	at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleErrorResponse(AwsXmlPredicatedResponseHandler.java:156)
	at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleResponse(AwsXmlPredicatedResponseHandler.java:108)
	at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:85)
```

If we do not upload any multi parts to S3, we have no list of etag responses to "commit" via `S3AsyncClient.completeMultipartUpload`, which seems to be mandatory, hence the error. 

This PR introduces a a boolean `uploadEmptyFile` (set to `false` by default) on the `S3.uploadFileMultipart` method, to determine how to handle this scenario. If set to `false` (default) and no data has passed through the stream, it will gracefully abort the multi-part upload request. If set to true, and no data has passed through the stream, an empty file will be uploaded on completion. An `Option[ETag]` of `None` will be emitted on the stream if no file was uploaded, else a `Some(ETag)` will be emitted.

The change of the return type on the method `S3.uploadFileMultipart` from `Pipe[F, Byte, ETag]` to `Pipe[F, Byte, Option[ETag]]` would be considered a breaking change, albeit a small one, and not provide too much inconvenience for clients consuming the ETag.

