### PR TITLE
Catch errors in Deferred

### DIFF
--- a/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/StreamScan.scala
+++ b/fs2-aws-dynamodb/src/main/scala/fs2/aws/dynamodb/StreamScan.scala
@@ -42,6 +42,9 @@ object StreamScan {
             ddb
               .scanPaginator(scanRequest)
               .map { publisher =>
+                // subscribe to the paginator, every time we request to deliver next pageSize items from the DDB table
+                // we use FS2 Queue as bounded buffer with size 1, this way we implement back pressure, not allowing
+                // paginator exhaust memory
                 publisher.subscribe(new Subscriber[ScanResponse] {
 
                   override def onSubscribe(s: Subscription): Unit =


### PR DESCRIPTION
Attempt to fix #986 

ATM onError calls `dispatcher.unsafeRunSync(Async[F].raiseError(t))` however in this case unsafeRunSync will throw the raised exception. 

I've added a Deferred instance to which can hold the exception. The queue can then be terminated using a None. The Deferred value is concatenated onto the end of the stream, once this terminates we can then check for any errors and raise them in the Stream.