### PR TITLE
Use Scaladex badge on ReadMe to show Scala version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fs2-aws
 ![Build](https://github.com/laserdisc-io/fs2-aws/workflows/Build/badge.svg)
 ![Release](https://github.com/laserdisc-io/fs2-aws/workflows/Release/badge.svg)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.laserdisc/fs2-aws_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.laserdisc/fs2-aws_2.12)
+[![fs2-aws-core Scala version support](https://index.scala-lang.org/laserdisc-io/fs2-aws/fs2-aws-core/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/laserdisc-io/fs2-aws/fs2-aws-core)
 [![Coverage Status](https://coveralls.io/repos/github/laserdisc-io/fs2-aws/badge.svg?branch=main)](https://coveralls.io/github/laserdisc-io/fs2-aws?branch=main)
 
 fs2 Streaming utilities for interacting with AWS


### PR DESCRIPTION
HI there! The current badge on the ReadMe from `maven-badges.herokuapp.com` is unfortunately broken:

<img width="911" height="228" alt="image" src="https://github.com/user-attachments/assets/be4a3306-0e37-4c50-b9f1-bd930c9e0393" />


...so here's a better replacement! This Scaladex badge summarises which versions of Scala are supported by `fs2-aws` (and what the latest `fs2-aws` version is for each of those Scala versions):

[![fs2-aws-core Scala version support](https://index.scala-lang.org/laserdisc-io/fs2-aws/fs2-aws-core/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/laserdisc-io/fs2-aws/fs2-aws-core)

More details on the badge format: https://github.com/scalacenter/scaladex/pull/660